### PR TITLE
fix: Test → Probe in lifecycle pipeline card

### DIFF
--- a/docs/Site/index.html
+++ b/docs/Site/index.html
@@ -447,10 +447,10 @@
     <!-- 04: VERIFY -->
     <a href="docs.html" class="lc-step">
       <div class="lc-stepnum">04 · VERIFY</div>
-      <div class="lc-stepname">Test</div>
+      <div class="lc-stepname">Probe</div>
       <div class="lc-cmd">agentward probe</div>
       <p class="lc-desc">Fires adversarial probes through the live proxy to prove policy catches what the scanner flagged. CI-ready with exit codes — fails the build if enforcement gaps exist.</p>
-      <div class="lc-artifact">→ Test results</div>
+      <div class="lc-artifact">→ Probe results</div>
     </a>
 
     <div class="lc-conn">→</div>


### PR DESCRIPTION
Renames the step label and artifact pill in the lc-step card from 'Test'/'Test results' to 'Probe'/'Probe results'.