### PR TITLE
Add declarative capability scoping for per-argument policy enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,128 @@ Agent Host                    AgentWard                     Tool Server
 | `agentward comply` | Evaluate policies against regulatory frameworks (HIPAA, SOX, GDPR, PCI-DSS) with auto-fix |
 | `agentward probe` | Policy regression testing — fire adversarial probes through the engine, verify policies block what they should |
 
+## Capability Scoping
+
+AgentWard's capability scoping turns per-resource allow/block switches into fine-grained **per-argument constraints** — evaluated in code at every tool call, outside the LLM context window.
+
+Where the top-level policy controls *which tools* can run, capability constraints control *what those tools can do with their arguments*.
+
+### YAML syntax
+
+```yaml
+skills:
+  filesystem-manager:
+    resources:
+      file:
+        read: true
+        write: true
+        capabilities:
+          write_file:
+            path:
+              must_start_with: ["/tmp/", "/workspace/"]
+              must_not_start_with: ["/etc/", "/home/"]
+              must_not_contain: [".."]          # block path traversal sequences
+
+  network-tools:
+    resources:
+      http:
+        read: true
+        capabilities:
+          http_request:
+            url:
+              allowed_domains: ["api.github.com", "api.slack.com"]
+              blocked_domains: ["*.internal.corp"]
+              allowed_schemes: ["https"]        # enforce TLS
+            method:
+              one_of: ["GET", "POST"]           # no DELETE/PUT
+
+  scanning-tools:
+    resources:
+      nmap:
+        read: true
+        capabilities:
+          nmap_scan:
+            target:
+              allowed_cidrs: ["10.0.0.0/8", "192.168.0.0/16"]
+              blocked_cidrs: ["0.0.0.0/0"]     # catch-all applied after allowlist
+            scan_type:
+              one_of: ["connect", "version"]
+            max_ports:
+              max_value: 100
+```
+
+### Constraint reference
+
+**String constraints** — apply to any `str`-valued argument:
+
+| Constraint | Effect |
+|---|---|
+| `must_start_with: [prefixes]` | Value must start with at least one prefix |
+| `must_not_start_with: [prefixes]` | Value must NOT start with any prefix |
+| `must_contain: [substrings]` | Value must contain at least one substring |
+| `must_not_contain: [substrings]` | Value must NOT contain any substring |
+| `matches: [regex_patterns]` | Value must match at least one regex |
+| `not_matches: [regex_patterns]` | Value must NOT match any regex |
+| `one_of: [values]` | Value must be exactly one of these |
+| `not_one_of: [values]` | Value must NOT be any of these |
+| `allowlist: [glob_patterns]` | Value must match at least one glob (supports `**`) |
+| `blocklist: [glob_patterns]` | Value must NOT match any glob |
+| `max_length: N` | String length must be ≤ N |
+
+**Network constraints** — applied to URL/hostname/IP string arguments (stdlib only, no DNS resolution):
+
+| Constraint | Effect |
+|---|---|
+| `allowed_domains: [domains]` | Hostname must be in list (supports `*.example.com` wildcards) |
+| `blocked_domains: [domains]` | Hostname must NOT match any entry |
+| `allowed_schemes: [schemes]` | URL scheme must be in list (e.g. `["https"]`) |
+| `allowed_cidrs: [cidrs]` | IP must fall in at least one CIDR range |
+| `blocked_cidrs: [cidrs]` | IP must NOT fall in any CIDR range |
+| `allowed_ports: [ports]` | Port must be in list (integers or `"8000-9000"` range strings) |
+
+**Numeric constraints** — apply to `int`/`float` arguments:
+
+| Constraint | Effect |
+|---|---|
+| `min_value: N` | Value must be ≥ N (inclusive) |
+| `max_value: N` | Value must be ≤ N (inclusive) |
+| `one_of: [values]` | Value must be exactly one of these |
+
+**Boolean constraints:**
+
+| Constraint | Effect |
+|---|---|
+| `must_be: true/false` | Argument must be exactly this boolean |
+
+**Array constraints** — apply to `list`-valued arguments:
+
+| Constraint | Effect |
+|---|---|
+| `max_items: N` | List must have ≤ N elements |
+| `item_constraints: {}` | Apply any constraint set to each list element |
+
+### Design principles
+
+- **AND logic** — every specified constraint must pass; a single failure blocks the call.
+- **Fail-closed by default** — if a constraint is declared and the argument is missing, the call is blocked. Add `fail_open: true` to a specific argument constraint to allow it to be absent.
+- **Dot notation for nested arguments** — use `options.timeout` to constrain `arguments["options"]["timeout"]`.
+- **Zero new dependencies** — all evaluation uses Python stdlib (`ipaddress`, `fnmatch`, `re`, `urllib.parse`).
+- **Last gate before ALLOW** — constraints run after action-level and filter-level checks, immediately before the final ALLOW is returned. They cannot be bypassed by tool-name policy decisions.
+
+### Error messages
+
+When a constraint fails, AgentWard produces a specific, actionable block reason:
+
+```
+BLOCKED: Argument 'path' value '/etc/shadow' violates capability constraint
+'blocklist'. Matched forbidden pattern: '/etc/shadow'.
+
+BLOCKED: Argument 'url' value 'http://api.github.com' violates capability
+constraint 'allowed_schemes'. Scheme 'http' is not in allowed list: ['https'].
+```
+
+These messages appear in the audit log, the terminal proxy output, and `agentward status`.
+
 ## Policy Actions
 
 | Action | Behavior |

--- a/agentward/policy/constraints.py
+++ b/agentward/policy/constraints.py
@@ -1,0 +1,705 @@
+"""Argument constraint evaluator for AgentWard capability scoping.
+
+Pure evaluation module — no side effects, no I/O, no dependency on the
+rest of the engine.  Given a tool call's arguments dict and the
+ArgumentConstraints declared for each parameter, returns a structured result
+describing which constraints passed and which failed.
+
+Design:
+  - evaluate_argument_constraints() is the single public entry point.
+  - All helper functions are pure (no state mutation, no globals).
+  - CIDR matching uses stdlib ``ipaddress``.
+  - Glob matching uses stdlib ``fnmatch``.
+  - URL parsing uses stdlib ``urllib.parse``.
+  - Regex patterns are pre-compiled on the ArgumentConstraints model;
+    the evaluator accesses them via the private attributes.
+
+Failure semantics:
+  - Constraints use AND logic: ALL specified constraints must pass.
+  - A missing argument defaults to BLOCK (fail-closed) unless the
+    ArgumentConstraints for that argument has ``fail_open: true``.
+  - Unknown constraint fields (future schema additions) are silently ignored
+    by the evaluator — it only checks what it recognises.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import ipaddress
+import urllib.parse
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agentward.policy.schema import ArgumentConstraints
+
+
+# ── Public result types ────────────────────────────────────────────────────────
+
+
+@dataclass
+class ConstraintViolation:
+    """Describes a single argument constraint that was not satisfied.
+
+    Attributes:
+        argument: Argument name or dot-notation path (e.g. ``"options.timeout"``).
+        constraint_type: The constraint kind that failed (e.g. ``"must_start_with"``).
+        value: The actual argument value that caused the violation.
+        message: Human-readable, actionable explanation suitable for audit logs
+                 and operator dashboards.
+    """
+
+    argument: str
+    constraint_type: str
+    value: Any
+    message: str
+
+
+@dataclass
+class ConstraintResult:
+    """Result of evaluating a tool call against its capability constraints.
+
+    Attributes:
+        passed: True only when every declared constraint was satisfied.
+        violations: List of individual failures (empty when passed is True).
+    """
+
+    passed: bool
+    violations: list[ConstraintViolation] = field(default_factory=list)
+
+
+# ── Public entry point ─────────────────────────────────────────────────────────
+
+
+def evaluate_argument_constraints(
+    arguments: dict[str, Any] | None,
+    arg_constraints: dict[str, "ArgumentConstraints"],
+) -> ConstraintResult:
+    """Evaluate tool call arguments against declared capability constraints.
+
+    Args:
+        arguments: The tool call arguments.  May be None if the tool takes no
+                   arguments.
+        arg_constraints: Mapping of argument name (or dot-path) to its
+                         ``ArgumentConstraints``.  Empty dict → instant PASS.
+
+    Returns:
+        ``ConstraintResult(passed=True)`` when all constraints are satisfied.
+        ``ConstraintResult(passed=False, violations=[...])`` otherwise.
+    """
+    if not arg_constraints:
+        return ConstraintResult(passed=True)
+
+    args = arguments or {}
+    violations: list[ConstraintViolation] = []
+
+    for arg_path, constraints in arg_constraints.items():
+        value, missing = _get_nested_value(args, arg_path)
+
+        if missing:
+            if not constraints.fail_open:
+                violations.append(
+                    ConstraintViolation(
+                        argument=arg_path,
+                        constraint_type="required",
+                        value=None,
+                        message=(
+                            f"BLOCKED: Argument '{arg_path}' is required by "
+                            f"capability constraints but was not provided."
+                        ),
+                    )
+                )
+            # Either way — skip further checks on a missing value.
+            continue
+
+        violations.extend(_check_value(arg_path, value, constraints))
+
+    return ConstraintResult(passed=len(violations) == 0, violations=violations)
+
+
+# ── Nested argument access ─────────────────────────────────────────────────────
+
+
+def _get_nested_value(arguments: dict[str, Any], path: str) -> tuple[Any, bool]:
+    """Retrieve a value from a nested dict using dot-notation.
+
+    Args:
+        arguments: The (potentially nested) arguments dict.
+        path: Dot-separated key path, e.g. ``"options.timeout"``.
+
+    Returns:
+        ``(value, False)`` if the path exists, ``(None, True)`` if missing.
+    """
+    parts = path.split(".")
+    current: Any = arguments
+    for part in parts:
+        if not isinstance(current, dict) or part not in current:
+            return None, True
+        current = current[part]
+    return current, False
+
+
+# ── Per-value dispatcher ───────────────────────────────────────────────────────
+
+
+def _check_value(
+    arg_path: str,
+    value: Any,
+    constraints: "ArgumentConstraints",
+) -> list[ConstraintViolation]:
+    """Check a single resolved argument value against all its constraints.
+
+    Args:
+        arg_path: Argument name / dot-path (used in violation messages).
+        value: The resolved argument value.
+        constraints: The full set of declared constraints for this argument.
+
+    Returns:
+        List of violations (empty = all constraints satisfied).
+    """
+    violations: list[ConstraintViolation] = []
+
+    # ── Boolean (must_be) — checked first; stops further type-specific checks ──
+    if constraints.must_be is not None:
+        if not isinstance(value, bool) or value != constraints.must_be:
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="must_be",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'must_be'. "
+                        f"Required: {constraints.must_be}."
+                    ),
+                )
+            )
+        # Return early — no further type-specific checks are meaningful.
+        return violations
+
+    # ── one_of / not_one_of (type-agnostic) ───────────────────────────────────
+    if constraints.one_of and value not in constraints.one_of:
+        violations.append(
+            ConstraintViolation(
+                argument=arg_path,
+                constraint_type="one_of",
+                value=value,
+                message=(
+                    f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                    f"capability constraint 'one_of'. "
+                    f"Allowed values: {constraints.one_of}."
+                ),
+            )
+        )
+
+    if constraints.not_one_of and value in constraints.not_one_of:
+        violations.append(
+            ConstraintViolation(
+                argument=arg_path,
+                constraint_type="not_one_of",
+                value=value,
+                message=(
+                    f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                    f"capability constraint 'not_one_of'. "
+                    f"Forbidden values: {constraints.not_one_of}."
+                ),
+            )
+        )
+
+    # ── Numeric constraints ────────────────────────────────────────────────────
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        violations.extend(_check_numeric(arg_path, value, constraints))
+
+    # ── Array constraints ──────────────────────────────────────────────────────
+    if isinstance(value, list):
+        violations.extend(_check_array(arg_path, value, constraints))
+
+    # ── String constraints (includes network constraints for URL strings) ──────
+    if isinstance(value, str):
+        violations.extend(_check_string(arg_path, value, constraints))
+
+    return violations
+
+
+# ── Numeric ────────────────────────────────────────────────────────────────────
+
+
+def _check_numeric(
+    arg_path: str,
+    value: int | float,
+    constraints: "ArgumentConstraints",
+) -> list[ConstraintViolation]:
+    violations: list[ConstraintViolation] = []
+
+    if constraints.min_value is not None and value < constraints.min_value:
+        violations.append(
+            ConstraintViolation(
+                argument=arg_path,
+                constraint_type="min_value",
+                value=value,
+                message=(
+                    f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                    f"capability constraint 'min_value'. "
+                    f"Minimum: {constraints.min_value}."
+                ),
+            )
+        )
+
+    if constraints.max_value is not None and value > constraints.max_value:
+        violations.append(
+            ConstraintViolation(
+                argument=arg_path,
+                constraint_type="max_value",
+                value=value,
+                message=(
+                    f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                    f"capability constraint 'max_value'. "
+                    f"Maximum: {constraints.max_value}."
+                ),
+            )
+        )
+
+    return violations
+
+
+# ── Array ──────────────────────────────────────────────────────────────────────
+
+
+def _check_array(
+    arg_path: str,
+    value: list[Any],
+    constraints: "ArgumentConstraints",
+) -> list[ConstraintViolation]:
+    violations: list[ConstraintViolation] = []
+
+    if constraints.max_items is not None and len(value) > constraints.max_items:
+        violations.append(
+            ConstraintViolation(
+                argument=arg_path,
+                constraint_type="max_items",
+                value=value,
+                message=(
+                    f"BLOCKED: Argument '{arg_path}' has {len(value)} items, "
+                    f"violating capability constraint 'max_items'. "
+                    f"Maximum allowed: {constraints.max_items}."
+                ),
+            )
+        )
+
+    if constraints.item_constraints is not None:
+        for idx, item in enumerate(value):
+            item_path = f"{arg_path}[{idx}]"
+            item_violations = _check_value(item_path, item, constraints.item_constraints)
+            violations.extend(item_violations)
+
+    return violations
+
+
+# ── String ─────────────────────────────────────────────────────────────────────
+
+
+def _check_string(
+    arg_path: str,
+    value: str,
+    constraints: "ArgumentConstraints",
+) -> list[ConstraintViolation]:
+    violations: list[ConstraintViolation] = []
+
+    # max_length
+    if constraints.max_length is not None and len(value) > constraints.max_length:
+        violations.append(
+            ConstraintViolation(
+                argument=arg_path,
+                constraint_type="max_length",
+                value=value,
+                message=(
+                    f"BLOCKED: Argument '{arg_path}' value exceeds max length "
+                    f"({len(value)} > {constraints.max_length})."
+                ),
+            )
+        )
+
+    # must_start_with
+    if constraints.must_start_with:
+        if not any(value.startswith(prefix) for prefix in constraints.must_start_with):
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="must_start_with",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'must_start_with'. "
+                        f"Allowed prefixes: {constraints.must_start_with}."
+                    ),
+                )
+            )
+
+    # must_not_start_with
+    for prefix in constraints.must_not_start_with:
+        if value.startswith(prefix):
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="must_not_start_with",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'must_not_start_with'. "
+                        f"Forbidden prefix: {prefix!r}."
+                    ),
+                )
+            )
+            break  # Report first offending prefix only
+
+    # must_contain
+    if constraints.must_contain:
+        if not any(sub in value for sub in constraints.must_contain):
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="must_contain",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'must_contain'. "
+                        f"Value must contain at least one of: {constraints.must_contain}."
+                    ),
+                )
+            )
+
+    # must_not_contain
+    for substring in constraints.must_not_contain:
+        if substring in value:
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="must_not_contain",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'must_not_contain'. "
+                        f"Forbidden substring: {substring!r}."
+                    ),
+                )
+            )
+            break  # Report first offending substring only
+
+    # matches (pre-compiled regexes from _compiled_matches private attr)
+    if constraints.matches:
+        compiled = constraints._compiled_matches  # noqa: SLF001
+        if not any(p.search(value) for p in compiled):
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="matches",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'matches'. "
+                        f"Value must match at least one of: {constraints.matches}."
+                    ),
+                )
+            )
+
+    # not_matches (pre-compiled regexes from _compiled_not_matches private attr)
+    compiled_not = constraints._compiled_not_matches  # noqa: SLF001
+    for idx, pattern in enumerate(compiled_not):
+        if pattern.search(value):
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="not_matches",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'not_matches'. "
+                        f"Value must not match: {constraints.not_matches[idx]!r}."
+                    ),
+                )
+            )
+            break  # Report first offending pattern only
+
+    # allowlist (glob patterns)
+    if constraints.allowlist:
+        if not any(fnmatch.fnmatch(value, pattern) for pattern in constraints.allowlist):
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="allowlist",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'allowlist'. "
+                        f"Allowed patterns: {constraints.allowlist}."
+                    ),
+                )
+            )
+
+    # blocklist (glob patterns)
+    for pattern in constraints.blocklist:
+        if fnmatch.fnmatch(value, pattern):
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="blocklist",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'blocklist'. "
+                        f"Matched forbidden pattern: {pattern!r}."
+                    ),
+                )
+            )
+            break  # Report first offending pattern only
+
+    # ── Network constraints ────────────────────────────────────────────────────
+    has_network = (
+        constraints.allowed_domains
+        or constraints.blocked_domains
+        or constraints.allowed_schemes
+        or constraints.allowed_cidrs
+        or constraints.blocked_cidrs
+        or constraints.allowed_ports
+    )
+    if has_network:
+        violations.extend(_check_network(arg_path, value, constraints))
+
+    return violations
+
+
+# ── Network ────────────────────────────────────────────────────────────────────
+
+
+def _check_network(
+    arg_path: str,
+    value: str,
+    constraints: "ArgumentConstraints",
+) -> list[ConstraintViolation]:
+    """Evaluate network-specific constraints on a URL/hostname/IP string."""
+    violations: list[ConstraintViolation] = []
+
+    parsed = _parse_url_lenient(value)
+    hostname = parsed.hostname or ""  # empty string if unparseable
+    scheme = parsed.scheme or ""
+    port = parsed.port  # None if not specified
+
+    # allowed_schemes
+    if constraints.allowed_schemes and scheme:
+        if scheme.lower() not in [s.lower() for s in constraints.allowed_schemes]:
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="allowed_schemes",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'allowed_schemes'. "
+                        f"Scheme {scheme!r} is not in allowed list: "
+                        f"{constraints.allowed_schemes}."
+                    ),
+                )
+            )
+
+    # allowed_domains — hostname must match at least one
+    if constraints.allowed_domains and hostname:
+        if not any(
+            _domain_matches(hostname, pattern) for pattern in constraints.allowed_domains
+        ):
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="allowed_domains",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'allowed_domains'. "
+                        f"Hostname {hostname!r} is not in allowed domains: "
+                        f"{constraints.allowed_domains}."
+                    ),
+                )
+            )
+
+    # blocked_domains — hostname must not match any
+    for pattern in constraints.blocked_domains:
+        if hostname and _domain_matches(hostname, pattern):
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="blocked_domains",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'blocked_domains'. "
+                        f"Hostname {hostname!r} matched forbidden pattern {pattern!r}."
+                    ),
+                )
+            )
+            break
+
+    # allowed_ports
+    if constraints.allowed_ports and port is not None:
+        if not _port_in_list(port, constraints.allowed_ports):
+            violations.append(
+                ConstraintViolation(
+                    argument=arg_path,
+                    constraint_type="allowed_ports",
+                    value=value,
+                    message=(
+                        f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                        f"capability constraint 'allowed_ports'. "
+                        f"Port {port} is not in allowed ports: "
+                        f"{constraints.allowed_ports}."
+                    ),
+                )
+            )
+
+    # CIDR constraints — attempt to resolve hostname as IP
+    if constraints.allowed_cidrs or constraints.blocked_cidrs:
+        ip = _resolve_to_ip(hostname)
+        if ip is not None:
+            if constraints.allowed_cidrs and not _ip_in_any_cidr(ip, constraints.allowed_cidrs):
+                violations.append(
+                    ConstraintViolation(
+                        argument=arg_path,
+                        constraint_type="allowed_cidrs",
+                        value=value,
+                        message=(
+                            f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                            f"capability constraint 'allowed_cidrs'. "
+                            f"IP {hostname!r} is not in allowed ranges: "
+                            f"{constraints.allowed_cidrs}."
+                        ),
+                    )
+                )
+
+            for cidr in constraints.blocked_cidrs:
+                if _ip_in_cidr(ip, cidr):
+                    violations.append(
+                        ConstraintViolation(
+                            argument=arg_path,
+                            constraint_type="blocked_cidrs",
+                            value=value,
+                            message=(
+                                f"BLOCKED: Argument '{arg_path}' value {value!r} violates "
+                                f"capability constraint 'blocked_cidrs'. "
+                                f"IP {hostname!r} falls within blocked range {cidr!r}."
+                            ),
+                        )
+                    )
+                    break
+
+    return violations
+
+
+# ── Network helpers ────────────────────────────────────────────────────────────
+
+
+def _parse_url_lenient(value: str) -> urllib.parse.ParseResult:
+    """Parse a string as a URL, adding a scheme if absent.
+
+    Handles raw hostnames/IPs (no scheme) by prepending ``https://`` so that
+    ``urllib.parse.urlparse`` can extract the hostname correctly.
+    """
+    # If value has no scheme, prepend one so urlparse works
+    if "://" not in value:
+        value = "https://" + value
+    return urllib.parse.urlparse(value)
+
+
+def _domain_matches(hostname: str, pattern: str) -> bool:
+    """Check if a hostname matches a domain pattern.
+
+    Patterns:
+      - ``"api.github.com"``     → exact match only
+      - ``"*.github.com"``       → matches ``api.github.com`` but NOT ``github.com``
+                                   and NOT ``deep.api.github.com``
+
+    Args:
+        hostname: The resolved hostname from the URL/argument.
+        pattern: A literal domain or a ``*.``-prefixed wildcard pattern.
+
+    Returns:
+        True if the hostname matches the pattern.
+    """
+    hostname = hostname.lower()
+    pattern = pattern.lower()
+
+    if pattern.startswith("*."):
+        suffix = pattern[2:]  # e.g. "github.com"
+        # Must end with ".suffix" AND have exactly one subdomain level
+        if hostname == suffix:
+            return False  # exact domain doesn't satisfy *.domain
+        return hostname.endswith("." + suffix)
+
+    return hostname == pattern
+
+
+def _port_in_list(port: int, allowed: list[str | int]) -> bool:
+    """Check if a port is in an allowed-ports list (integers or range strings).
+
+    Args:
+        port: The port number to check.
+        allowed: List of allowed entries: plain ints or ``"start-end"`` strings.
+
+    Returns:
+        True if the port is covered by any entry.
+    """
+    for entry in allowed:
+        if isinstance(entry, int):
+            if port == entry:
+                return True
+        elif isinstance(entry, str):
+            if "-" in entry:
+                try:
+                    start, end = entry.split("-", 1)
+                    if int(start) <= port <= int(end):
+                        return True
+                except (ValueError, TypeError):
+                    pass  # Malformed range — skip
+            else:
+                try:
+                    if port == int(entry):
+                        return True
+                except (ValueError, TypeError):
+                    pass
+    return False
+
+
+def _resolve_to_ip(hostname: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Try to parse a hostname string as a literal IP address.
+
+    Returns None if the string is a DNS name rather than a literal IP.
+    No DNS resolution is performed — CIDR checks only work for literal IPs.
+    """
+    if not hostname:
+        return None
+    try:
+        return ipaddress.ip_address(hostname)
+    except ValueError:
+        return None
+
+
+def _ip_in_cidr(ip: ipaddress.IPv4Address | ipaddress.IPv6Address, cidr: str) -> bool:
+    """Check if an IP address falls within a CIDR range.
+
+    Args:
+        ip: A parsed IP address object.
+        cidr: A CIDR string like ``"10.0.0.0/8"``.
+
+    Returns:
+        True if the IP is within the network.  False on any parse error.
+    """
+    try:
+        network = ipaddress.ip_network(cidr, strict=False)
+        return ip in network
+    except ValueError:
+        return False  # Malformed CIDR — treat as no-match
+
+
+def _ip_in_any_cidr(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    cidrs: list[str],
+) -> bool:
+    """Check if an IP address falls within any CIDR in the list."""
+    return any(_ip_in_cidr(ip, cidr) for cidr in cidrs)

--- a/agentward/policy/engine.py
+++ b/agentward/policy/engine.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from agentward.policy.constraints import (
+    ConstraintViolation,
+    evaluate_argument_constraints,
+)
 from agentward.policy.protected_paths import check_arguments as _check_protected_paths
 from agentward.policy.schema import (
     AgentWardPolicy,
@@ -40,6 +44,25 @@ class EvaluationResult:
     reason: str
     skill: str | None = None
     resource: str | None = None
+
+
+def _format_constraint_violations(
+    tool_name: str,
+    violations: list[ConstraintViolation],
+) -> str:
+    """Format constraint violations into a concise, actionable block reason.
+
+    Args:
+        tool_name: The tool name (used in the first violation message).
+        violations: Non-empty list of constraint violations.
+
+    Returns:
+        A human-readable string suitable for audit logs and operator dashboards.
+    """
+    if not violations:
+        return f"Tool '{tool_name}' blocked by capability constraints."
+    # Violations already contain BLOCKED: prefixed messages.
+    return " ".join(v.message for v in violations)
 
 
 class PolicyEngine:
@@ -284,12 +307,17 @@ class PolicyEngine:
         if action is not None:
             allowed = permissions.is_action_allowed(action)
             if allowed is True:
-                # Action allowed — check filters before final ALLOW
+                # Action allowed — check filters then capability constraints.
                 filter_result = self._check_filters(
                     tool_name, skill_name, resource_name, permissions, arguments
                 )
                 if filter_result is not None:
                     return filter_result
+                cap_result = self._check_capabilities(
+                    tool_name, skill_name, resource_name, permissions, arguments
+                )
+                if cap_result is not None:
+                    return cap_result
                 return EvaluationResult(
                     decision=PolicyDecision.ALLOW,
                     reason=(
@@ -343,12 +371,18 @@ class PolicyEngine:
                 resource=resource_name,
             )
 
-        # Final ALLOW — check filters first
+        # Final ALLOW — check filters then capability constraints.
         filter_result = self._check_filters(
             tool_name, skill_name, resource_name, permissions, arguments
         )
         if filter_result is not None:
             return filter_result
+
+        cap_result = self._check_capabilities(
+            tool_name, skill_name, resource_name, permissions, arguments
+        )
+        if cap_result is not None:
+            return cap_result
 
         return EvaluationResult(
             decision=PolicyDecision.ALLOW,
@@ -443,6 +477,49 @@ class PolicyEngine:
             return role_result
 
         return None
+
+    def _check_capabilities(
+        self,
+        tool_name: str,
+        skill_name: str,
+        resource_name: str,
+        permissions: ResourcePermissions,
+        arguments: dict[str, Any] | None,
+    ) -> EvaluationResult | None:
+        """Check argument constraints from the capabilities block.
+
+        This is the last gate before ALLOW — runs after action-level and
+        filter-level checks have already passed.
+
+        Args:
+            tool_name: The full MCP tool name (used to look up capability constraints).
+            skill_name: The matched skill (for EvaluationResult context).
+            resource_name: The matched resource (for EvaluationResult context).
+            permissions: Resource permissions, which may carry ``capabilities``.
+            arguments: Tool call arguments to evaluate.
+
+        Returns:
+            A BLOCK EvaluationResult if any constraint fails, None if all pass
+            or if no capability constraints are defined for this tool.
+        """
+        if not permissions.capabilities:
+            return None
+
+        tool_caps = permissions.capabilities.get(tool_name)
+        if not tool_caps:
+            return None
+
+        result = evaluate_argument_constraints(arguments, tool_caps)
+        if result.passed:
+            return None
+
+        reason = _format_constraint_violations(tool_name, result.violations)
+        return EvaluationResult(
+            decision=PolicyDecision.BLOCK,
+            reason=reason,
+            skill=skill_name,
+            resource=resource_name,
+        )
 
     def _check_role_filters(
         self,

--- a/agentward/policy/schema.py
+++ b/agentward/policy/schema.py
@@ -1,7 +1,7 @@
 """Pydantic v2 models for AgentWard policy YAML.
 
 Defines the complete schema for agentward.yaml, including skill permissions,
-chaining rules, approval gates, and data boundary zones.
+chaining rules, approval gates, data boundary zones, and argument constraints.
 """
 
 from __future__ import annotations
@@ -53,6 +53,184 @@ class ViolationAction(str, Enum):
     LOG_ONLY = "log_only"
 
 
+class ArgumentConstraints(BaseModel):
+    """Declarative constraints on a single tool argument for capability scoping.
+
+    All defined constraints use AND logic — every specified constraint must
+    pass for the argument to be accepted.  If any constraint fails, the tool
+    call is BLOCKED with a specific, actionable error message.
+
+    Constraints are grouped by the type of value they apply to:
+    - String constraints apply to any string-valued argument.
+    - Network constraints apply to URL/hostname/IP string arguments.
+    - Numeric constraints apply to int/float arguments.
+    - Boolean constraints apply to bool arguments.
+    - Array constraints apply to list arguments.
+
+    Regex patterns in ``matches``/``not_matches`` are compiled at policy
+    load time so invalid patterns fail fast rather than crashing mid-session.
+
+    Example YAML::
+
+        capabilities:
+          write_file:
+            path:
+              must_start_with: ["/tmp/", "/workspace/"]
+              must_not_contain: [".."]
+              blocklist: ["/etc/shadow", "/etc/passwd"]
+          http_request:
+            url:
+              allowed_domains: ["api.github.com"]
+              allowed_schemes: ["https"]
+            method:
+              one_of: ["GET", "POST"]
+    """
+
+    # ── String constraints ─────────────────────────────────────────────────
+    must_start_with: list[str] = Field(
+        default_factory=list,
+        description="Value must start with at least one of these prefixes.",
+    )
+    must_not_start_with: list[str] = Field(
+        default_factory=list,
+        description="Value must NOT start with any of these prefixes.",
+    )
+    must_contain: list[str] = Field(
+        default_factory=list,
+        description="Value must contain at least one of these substrings.",
+    )
+    must_not_contain: list[str] = Field(
+        default_factory=list,
+        description="Value must NOT contain any of these substrings.",
+    )
+    matches: list[str] = Field(
+        default_factory=list,
+        description="Regex patterns — value must match at least one.",
+    )
+    not_matches: list[str] = Field(
+        default_factory=list,
+        description="Regex patterns — value must NOT match any.",
+    )
+    one_of: list[Any] = Field(
+        default_factory=list,
+        description="Value must be exactly one of these (enum allowlist).",
+    )
+    not_one_of: list[Any] = Field(
+        default_factory=list,
+        description="Value must NOT be any of these.",
+    )
+    allowlist: list[str] = Field(
+        default_factory=list,
+        description="Glob patterns — string value must match at least one.",
+    )
+    blocklist: list[str] = Field(
+        default_factory=list,
+        description="Glob patterns — string value must NOT match any.",
+    )
+    max_length: int | None = Field(
+        default=None,
+        description="Maximum allowed string length.",
+    )
+
+    # ── Network constraints (URL / hostname / IP arguments) ───────────────
+    allowed_domains: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Allowed hostnames. Supports wildcard prefix: *.example.com "
+            "matches api.example.com but not example.com itself."
+        ),
+    )
+    blocked_domains: list[str] = Field(
+        default_factory=list,
+        description="Blocked hostnames with the same wildcard support.",
+    )
+    allowed_schemes: list[str] = Field(
+        default_factory=list,
+        description="Allowed URL schemes, e.g. ['https'].",
+    )
+    allowed_cidrs: list[str] = Field(
+        default_factory=list,
+        description="Allowed IP/CIDR ranges, e.g. ['10.0.0.0/8'].",
+    )
+    blocked_cidrs: list[str] = Field(
+        default_factory=list,
+        description="Blocked IP/CIDR ranges, e.g. ['0.0.0.0/0'].",
+    )
+    allowed_ports: list[str | int] = Field(
+        default_factory=list,
+        description=(
+            "Allowed ports or port ranges. "
+            "Accepts integers (443) or range strings ('8000-9000')."
+        ),
+    )
+
+    # ── Numeric constraints ────────────────────────────────────────────────
+    min_value: float | None = Field(
+        default=None,
+        description="Minimum allowed numeric value (inclusive).",
+    )
+    max_value: float | None = Field(
+        default=None,
+        description="Maximum allowed numeric value (inclusive).",
+    )
+
+    # ── Boolean constraints ────────────────────────────────────────────────
+    must_be: bool | None = Field(
+        default=None,
+        description="Argument must be exactly this boolean value.",
+    )
+
+    # ── Array constraints ──────────────────────────────────────────────────
+    max_items: int | None = Field(
+        default=None,
+        description="Maximum number of items in a list argument.",
+    )
+    item_constraints: ArgumentConstraints | None = Field(
+        default=None,
+        description="Constraints applied to each element of a list argument.",
+    )
+
+    # ── Missing-argument behaviour ─────────────────────────────────────────
+    fail_open: bool = Field(
+        default=False,
+        description=(
+            "When True, a missing argument silently passes all constraints "
+            "(fail-open). Default False: missing required arguments BLOCK."
+        ),
+    )
+
+    # Pre-compiled regex patterns (populated by the validator below).
+    _compiled_matches: list[re.Pattern[str]] = PrivateAttr(default_factory=list)
+    _compiled_not_matches: list[re.Pattern[str]] = PrivateAttr(default_factory=list)
+
+    @model_validator(mode="after")
+    def _compile_regex_patterns(self) -> "ArgumentConstraints":
+        """Pre-compile regex patterns at load time — fail fast on bad patterns."""
+        for pattern_str in self.matches:
+            try:
+                self._compiled_matches.append(re.compile(pattern_str))
+            except re.error as e:
+                msg = (
+                    f"Invalid regex in 'matches': {pattern_str!r} — {e}. "
+                    f"Fix this pattern in your capability constraints."
+                )
+                raise ValueError(msg) from e
+        for pattern_str in self.not_matches:
+            try:
+                self._compiled_not_matches.append(re.compile(pattern_str))
+            except re.error as e:
+                msg = (
+                    f"Invalid regex in 'not_matches': {pattern_str!r} — {e}. "
+                    f"Fix this pattern in your capability constraints."
+                )
+                raise ValueError(msg) from e
+        return self
+
+
+# Self-referential model requires rebuild after initial class definition.
+ArgumentConstraints.model_rebuild()
+
+
 class ResourcePermissions(BaseModel):
     """Permissions for one resource within a skill.
 
@@ -66,6 +244,14 @@ class ResourcePermissions(BaseModel):
     denied: bool = False
     actions: dict[str, bool] = Field(default_factory=dict)
     filters: dict[str, list[str]] = Field(default_factory=dict)
+    capabilities: dict[str, dict[str, ArgumentConstraints]] = Field(
+        default_factory=dict,
+        description=(
+            "Per-tool argument constraints for capability scoping. "
+            "Keyed by tool name, then argument name. "
+            "All constraints on an argument use AND logic."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -77,14 +263,21 @@ class ResourcePermissions(BaseModel):
 
         # If explicitly denied, nothing else matters
         if data.get("denied") is True:
-            return {"denied": True, "actions": {}, "filters": {}}
+            return {"denied": True, "actions": {}, "filters": {}, "capabilities": {}}
 
         actions: dict[str, bool] = {}
         filters: dict[str, list[str]] = {}
+        # Raw dict passed through to Pydantic for ArgumentConstraints parsing.
+        capabilities: dict[str, Any] = {}
 
         for key, value in data.items():
             if key == "denied":
                 continue
+            elif key == "capabilities":
+                if not isinstance(value, dict):
+                    msg = "capabilities must be a mapping"
+                    raise ValueError(msg)
+                capabilities = value
             elif key == "filters":
                 if not isinstance(value, dict):
                     msg = "filters must be a mapping"
@@ -116,7 +309,12 @@ class ResourcePermissions(BaseModel):
                     )
                     raise ValueError(msg)
 
-        return {"denied": False, "actions": actions, "filters": filters}
+        return {
+            "denied": False,
+            "actions": actions,
+            "filters": filters,
+            "capabilities": capabilities,
+        }
 
     def is_action_allowed(self, action: str) -> bool | None:
         """Check if a specific action is allowed.

--- a/agentward/testing/probes/capability_network_scope.yaml
+++ b/agentward/testing/probes/capability_network_scope.yaml
@@ -1,0 +1,145 @@
+probes:
+  - name: capability_network_blocked_domain
+    category: scope_creep
+    severity: critical
+    description: >
+      Attempts an HTTP request to a domain not in the allowed_domains list.
+      The capability constraint must block requests to unauthorized external services.
+    expected: BLOCK
+    tool_name: http_request
+    arguments:
+      url: "https://evil.com/exfiltrate"
+      method: "POST"
+    requires_policy_feature: capabilities
+
+  - name: capability_network_internal_corp_wildcard
+    category: scope_creep
+    severity: critical
+    description: >
+      Attempts to reach an internal corporate service using a *.internal.corp
+      hostname. blocked_domains: ["*.internal.corp"] must block this.
+    expected: BLOCK
+    tool_name: http_request
+    arguments:
+      url: "https://secrets.internal.corp/api/keys"
+      method: "GET"
+    requires_policy_feature: capabilities
+
+  - name: capability_network_http_scheme_blocked
+    category: scope_creep
+    severity: high
+    description: >
+      Uses http:// instead of https:// to bypass TLS. allowed_schemes: ["https"]
+      must block plaintext HTTP requests.
+    expected: BLOCK
+    tool_name: http_request
+    arguments:
+      url: "http://api.github.com/repos"
+      method: "GET"
+    requires_policy_feature: capabilities
+
+  - name: capability_network_allowed_domain_allowed
+    category: scope_creep
+    severity: low
+    description: >
+      A legitimate HTTPS request to an allowed domain should pass.
+    expected: ALLOW
+    tool_name: http_request
+    arguments:
+      url: "https://api.github.com/v3/repos"
+      method: "GET"
+    requires_policy_feature: capabilities
+
+  - name: capability_network_method_delete_blocked
+    category: scope_creep
+    severity: high
+    description: >
+      Attempts to use the DELETE method when only GET and POST are allowed.
+      one_of constraint on method must block this.
+    expected: BLOCK
+    tool_name: http_request
+    arguments:
+      url: "https://api.github.com/repos/myrepo"
+      method: "DELETE"
+    requires_policy_feature: capabilities
+
+  - name: capability_network_cidr_public_ip_blocked
+    category: scope_creep
+    severity: critical
+    description: >
+      Attempts to reach a public IP (8.8.8.8) when only RFC-1918 ranges are
+      allowed. allowed_cidrs: ["10.0.0.0/8", "192.168.0.0/16"] must block this.
+    expected: BLOCK
+    tool_name: nmap_scan
+    arguments:
+      target: "8.8.8.8"
+      scan_type: "connect"
+      max_ports: 50
+    requires_policy_feature: capabilities
+
+  - name: capability_network_cidr_private_range_allowed
+    category: scope_creep
+    severity: low
+    description: >
+      A scan against a host in the allowed private range should pass.
+    expected: ALLOW
+    tool_name: nmap_scan
+    arguments:
+      target: "10.0.1.100"
+      scan_type: "connect"
+      max_ports: 50
+    requires_policy_feature: capabilities
+
+  - name: capability_network_scan_type_stealth_blocked
+    category: scope_creep
+    severity: high
+    description: >
+      Attempts a stealth SYN scan (scan_type="stealth") when only
+      ["connect", "version"] are permitted.
+    expected: BLOCK
+    tool_name: nmap_scan
+    arguments:
+      target: "10.0.1.100"
+      scan_type: "stealth"
+      max_ports: 50
+    requires_policy_feature: capabilities
+
+  - name: capability_network_max_ports_exceeded
+    category: scope_creep
+    severity: high
+    description: >
+      Requests a port scan of 65535 ports when max_value: 100 is enforced.
+    expected: BLOCK
+    tool_name: nmap_scan
+    arguments:
+      target: "10.0.1.100"
+      scan_type: "connect"
+      max_ports: 65535
+    requires_policy_feature: capabilities
+
+  - name: capability_network_slash_zero_cidr_blocked
+    category: scope_creep
+    severity: critical
+    description: >
+      Verifies that blocked_cidrs: ["0.0.0.0/0"] prevents scanning any
+      public IP when the policy is configured in deny-all network mode.
+    expected: BLOCK
+    tool_name: nmap_scan
+    arguments:
+      target: "1.2.3.4"
+      scan_type: "connect"
+      max_ports: 1
+    requires_policy_feature: capabilities
+
+  - name: capability_network_no_scheme_hostname_checked
+    category: scope_creep
+    severity: medium
+    description: >
+      A bare hostname (without scheme) that is not in allowed_domains must be
+      blocked. The evaluator must handle scheme-less strings gracefully.
+    expected: BLOCK
+    tool_name: http_request
+    arguments:
+      url: "malicious.example.org/steal"
+      method: "GET"
+    requires_policy_feature: capabilities

--- a/agentward/testing/probes/capability_path_traversal.yaml
+++ b/agentward/testing/probes/capability_path_traversal.yaml
@@ -1,0 +1,108 @@
+probes:
+  - name: capability_path_traversal_dotdot
+    category: path_traversal
+    severity: critical
+    description: >
+      Attempts to escape an allowed path prefix using a "../" traversal sequence.
+      Capability constraints with must_not_contain: [".."] must block this.
+    expected: BLOCK
+    tool_name: write_file
+    arguments:
+      path: "/workspace/../etc/passwd"
+    requires_policy_feature: capabilities
+
+  - name: capability_path_traversal_double_slash
+    category: path_traversal
+    severity: high
+    description: >
+      Uses "//etc" to attempt a path that starts with an allowed prefix but
+      navigates to a sensitive directory via the blocklist.
+    expected: BLOCK
+    tool_name: write_file
+    arguments:
+      path: "/etc/cron.d/backdoor"
+    requires_policy_feature: capabilities
+
+  - name: capability_path_traversal_absolute_escape
+    category: path_traversal
+    severity: critical
+    description: >
+      Provides an absolute path outside the allowed prefix set.
+      must_start_with must block access to /home/.
+    expected: BLOCK
+    tool_name: write_file
+    arguments:
+      path: "/home/user/.bashrc"
+    requires_policy_feature: capabilities
+
+  - name: capability_path_traversal_allowed_path
+    category: path_traversal
+    severity: low
+    description: >
+      A legitimate write to /tmp/ should be allowed when must_start_with
+      includes /tmp/.
+    expected: ALLOW
+    tool_name: write_file
+    arguments:
+      path: "/tmp/output.json"
+    requires_policy_feature: capabilities
+
+  - name: capability_path_blocklist_etc_shadow
+    category: path_traversal
+    severity: critical
+    description: >
+      Attempts to write directly to /etc/shadow.
+      blocklist must block this exact path.
+    expected: BLOCK
+    tool_name: read_file
+    arguments:
+      path: "/etc/shadow"
+    requires_policy_feature: capabilities
+
+  - name: capability_path_blocklist_etc_passwd
+    category: path_traversal
+    severity: critical
+    description: >
+      Attempts to read /etc/passwd.
+      blocklist must block this exact path.
+    expected: BLOCK
+    tool_name: read_file
+    arguments:
+      path: "/etc/passwd"
+    requires_policy_feature: capabilities
+
+  - name: capability_path_allowlist_workspace
+    category: path_traversal
+    severity: low
+    description: >
+      A legitimate read from /workspace/ should be allowed when the allowlist
+      includes /workspace/**.
+    expected: ALLOW
+    tool_name: read_file
+    arguments:
+      path: "/workspace/src/main.py"
+    requires_policy_feature: capabilities
+
+  - name: capability_path_missing_required_arg
+    category: path_traversal
+    severity: high
+    description: >
+      Calling write_file without a path argument when path constraints are
+      declared should be blocked (fail-closed default).
+    expected: BLOCK
+    tool_name: write_file
+    arguments: {}
+    requires_policy_feature: capabilities
+
+  - name: capability_path_traversal_url_encoded
+    category: path_traversal
+    severity: high
+    description: >
+      Attempts path traversal using URL-encoded sequences in the path argument.
+      must_not_contain: [".."] must catch the literal ".." even if URL-encoded
+      variants are used; this probe tests that the literal form is blocked.
+    expected: BLOCK
+    tool_name: write_file
+    arguments:
+      path: "/workspace/../../etc/hosts"
+    requires_policy_feature: capabilities

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,1178 @@
+"""Comprehensive tests for the argument constraint evaluator.
+
+Covers:
+  - All string constraint types
+  - Network constraints (domains, CIDRs, schemes, ports)
+  - Numeric constraints
+  - Boolean constraints
+  - Array constraints with item_constraints
+  - Nested argument access (dot notation)
+  - Missing argument handling (fail-open vs fail-closed)
+  - URL edge cases
+  - CIDR edge cases (IPv4, IPv6, /0, single IPs)
+  - Glob edge cases
+  - Engine integration (constraints wired into decision pipeline)
+  - Backward compatibility (no capabilities = works as before)
+  - Multiple constraints on same argument (AND logic)
+  - YAML round-trip (load YAML with capabilities, verify parsing)
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Any
+
+import pytest
+import yaml
+
+from agentward.policy.constraints import (
+    ConstraintResult,
+    ConstraintViolation,
+    _domain_matches,
+    _ip_in_cidr,
+    _parse_url_lenient,
+    _port_in_list,
+    evaluate_argument_constraints,
+)
+from agentward.policy.engine import PolicyEngine
+from agentward.policy.loader import load_policy
+from agentward.policy.schema import (
+    AgentWardPolicy,
+    ArgumentConstraints,
+    PolicyDecision,
+    ResourcePermissions,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def make_constraints(**kwargs: Any) -> ArgumentConstraints:
+    """Build an ArgumentConstraints model from keyword args."""
+    return ArgumentConstraints(**kwargs)
+
+
+def evaluate(
+    arg_constraints: dict[str, Any],
+    arguments: dict[str, Any] | None = None,
+) -> ConstraintResult:
+    """Build ArgumentConstraints from dicts and evaluate."""
+    typed = {k: ArgumentConstraints(**v) for k, v in arg_constraints.items()}
+    return evaluate_argument_constraints(arguments, typed)
+
+
+def passes(arg_constraints: dict[str, Any], arguments: dict[str, Any] | None) -> bool:
+    return evaluate(arg_constraints, arguments).passed
+
+
+def fails(arg_constraints: dict[str, Any], arguments: dict[str, Any] | None) -> bool:
+    return not evaluate(arg_constraints, arguments).passed
+
+
+# ── Empty / trivial ────────────────────────────────────────────────────────────
+
+
+class TestTrivialCases:
+    def test_no_constraints_passes(self) -> None:
+        result = evaluate_argument_constraints({"path": "/etc/passwd"}, {})
+        assert result.passed
+
+    def test_none_arguments_no_constraints(self) -> None:
+        result = evaluate_argument_constraints(None, {})
+        assert result.passed
+
+    def test_none_arguments_with_fail_open(self) -> None:
+        result = evaluate_argument_constraints(
+            None, {"path": make_constraints(must_start_with=["/tmp"], fail_open=True)}
+        )
+        assert result.passed
+
+    def test_none_arguments_fail_closed(self) -> None:
+        result = evaluate_argument_constraints(
+            None, {"path": make_constraints(must_start_with=["/tmp"])}
+        )
+        assert not result.passed
+        assert result.violations[0].constraint_type == "required"
+
+
+# ── Missing argument ───────────────────────────────────────────────────────────
+
+
+class TestMissingArgument:
+    def test_missing_arg_fail_closed_by_default(self) -> None:
+        assert fails({"path": {"must_start_with": ["/tmp"]}}, {})
+
+    def test_missing_arg_fail_open(self) -> None:
+        assert passes({"path": {"must_start_with": ["/tmp"], "fail_open": True}}, {})
+
+    def test_missing_arg_violation_message(self) -> None:
+        result = evaluate({"path": {"must_start_with": ["/tmp"]}}, {})
+        assert "path" in result.violations[0].message
+        assert "required" in result.violations[0].message.lower()
+
+    def test_missing_nested_arg_fail_closed(self) -> None:
+        assert fails({"options.timeout": {"max_value": 30}}, {"options": {}})
+
+    def test_missing_top_level_when_nested_exists(self) -> None:
+        # "options" key missing entirely
+        assert fails({"options.timeout": {"max_value": 30}}, {})
+
+
+# ── String: must_start_with ────────────────────────────────────────────────────
+
+
+class TestMustStartWith:
+    def test_passes_matching_prefix(self) -> None:
+        assert passes({"path": {"must_start_with": ["/tmp/", "/workspace/"]}}, {"path": "/tmp/foo"})
+
+    def test_passes_second_prefix(self) -> None:
+        assert passes({"path": {"must_start_with": ["/tmp/", "/workspace/"]}}, {"path": "/workspace/bar"})
+
+    def test_fails_no_matching_prefix(self) -> None:
+        result = evaluate({"path": {"must_start_with": ["/tmp/"]}}, {"path": "/etc/passwd"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "must_start_with"
+        assert "/etc/passwd" in result.violations[0].message
+
+    def test_violation_lists_allowed_prefixes(self) -> None:
+        result = evaluate({"path": {"must_start_with": ["/tmp/", "/workspace/"]}}, {"path": "/etc"})
+        assert "/tmp/" in result.violations[0].message
+        assert "/workspace/" in result.violations[0].message
+
+
+# ── String: must_not_start_with ────────────────────────────────────────────────
+
+
+class TestMustNotStartWith:
+    def test_passes_safe_path(self) -> None:
+        assert passes({"path": {"must_not_start_with": ["/etc/", "/home/"]}}, {"path": "/tmp/file"})
+
+    def test_fails_forbidden_prefix(self) -> None:
+        result = evaluate({"path": {"must_not_start_with": ["/etc/"]}}, {"path": "/etc/shadow"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "must_not_start_with"
+
+    def test_fails_second_forbidden_prefix(self) -> None:
+        assert fails({"path": {"must_not_start_with": ["/etc/", "/home/"]}}, {"path": "/home/user/.ssh"})
+
+
+# ── String: must_contain ───────────────────────────────────────────────────────
+
+
+class TestMustContain:
+    def test_passes_when_substring_present(self) -> None:
+        assert passes({"q": {"must_contain": ["approved"]}}, {"q": "this is approved"})
+
+    def test_fails_when_no_substring_present(self) -> None:
+        result = evaluate({"q": {"must_contain": ["approved"]}}, {"q": "pending"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "must_contain"
+
+    def test_passes_one_of_required_substrings(self) -> None:
+        assert passes({"q": {"must_contain": ["ok", "approved"]}}, {"q": "status: approved"})
+
+
+# ── String: must_not_contain ───────────────────────────────────────────────────
+
+
+class TestMustNotContain:
+    def test_passes_clean_value(self) -> None:
+        assert passes({"path": {"must_not_contain": [".."]}}, {"path": "/workspace/file.txt"})
+
+    def test_fails_traversal_sequence(self) -> None:
+        result = evaluate({"path": {"must_not_contain": [".."]}}, {"path": "/workspace/../etc/passwd"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "must_not_contain"
+
+    def test_fails_first_offending_substring_reported(self) -> None:
+        result = evaluate({"cmd": {"must_not_contain": ["rm", "sudo"]}}, {"cmd": "sudo rm -rf"})
+        # Should report at least one violation (stops at first match)
+        assert not result.passed
+
+
+# ── String: matches (regex) ────────────────────────────────────────────────────
+
+
+class TestMatches:
+    def test_passes_matching_regex(self) -> None:
+        assert passes({"email": {"matches": [r"^[^@]+@[^@]+\.[^@]+$"]}}, {"email": "user@example.com"})
+
+    def test_fails_non_matching_regex(self) -> None:
+        result = evaluate({"email": {"matches": [r"^[^@]+@[^@]+\.[^@]+$"]}}, {"email": "not-an-email"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "matches"
+
+    def test_passes_if_any_pattern_matches(self) -> None:
+        assert passes({"v": {"matches": [r"^\d+$", r"^v\d+"]}}, {"v": "v123"})
+
+    def test_invalid_regex_fails_at_load_time(self) -> None:
+        with pytest.raises(ValueError, match="Invalid regex"):
+            ArgumentConstraints(matches=["[invalid"])
+
+
+# ── String: not_matches ────────────────────────────────────────────────────────
+
+
+class TestNotMatches:
+    def test_passes_when_no_pattern_matches(self) -> None:
+        assert passes({"cmd": {"not_matches": [r"\brm\b", r"\bsudo\b"]}}, {"cmd": "ls -la"})
+
+    def test_fails_when_pattern_matches(self) -> None:
+        result = evaluate({"cmd": {"not_matches": [r"\brm\b"]}}, {"cmd": "rm -rf /tmp"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "not_matches"
+
+    def test_invalid_regex_fails_at_load_time(self) -> None:
+        with pytest.raises(ValueError, match="Invalid regex"):
+            ArgumentConstraints(not_matches=["[bad"])
+
+
+# ── String: one_of ─────────────────────────────────────────────────────────────
+
+
+class TestOneOf:
+    def test_passes_allowed_value(self) -> None:
+        assert passes({"method": {"one_of": ["GET", "POST"]}}, {"method": "GET"})
+
+    def test_fails_disallowed_value(self) -> None:
+        result = evaluate({"method": {"one_of": ["GET", "POST"]}}, {"method": "DELETE"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "one_of"
+
+    def test_numeric_one_of(self) -> None:
+        assert passes({"level": {"one_of": [1, 2, 3]}}, {"level": 2})
+        assert fails({"level": {"one_of": [1, 2, 3]}}, {"level": 5})
+
+
+# ── String: not_one_of ─────────────────────────────────────────────────────────
+
+
+class TestNotOneOf:
+    def test_passes_when_not_in_list(self) -> None:
+        assert passes({"method": {"not_one_of": ["DELETE", "DROP"]}}, {"method": "GET"})
+
+    def test_fails_when_in_forbidden_list(self) -> None:
+        result = evaluate({"method": {"not_one_of": ["DELETE"]}}, {"method": "DELETE"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "not_one_of"
+
+
+# ── String: allowlist (glob) ───────────────────────────────────────────────────
+
+
+class TestAllowlist:
+    def test_passes_matching_glob(self) -> None:
+        assert passes({"path": {"allowlist": ["/workspace/**", "/public/**"]}}, {"path": "/workspace/src/main.py"})
+
+    def test_passes_second_glob(self) -> None:
+        assert passes({"path": {"allowlist": ["/workspace/**", "/public/**"]}}, {"path": "/public/index.html"})
+
+    def test_fails_no_matching_glob(self) -> None:
+        result = evaluate({"path": {"allowlist": ["/workspace/**"]}}, {"path": "/etc/shadow"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "allowlist"
+
+    def test_double_star_glob_recursive(self) -> None:
+        assert passes({"path": {"allowlist": ["/workspace/**"]}}, {"path": "/workspace/a/b/c/d.txt"})
+
+    def test_single_star_glob_non_recursive(self) -> None:
+        # fnmatch: * matches everything including /
+        assert passes({"path": {"allowlist": ["/tmp/*.txt"]}}, {"path": "/tmp/notes.txt"})
+        # /tmp/a/b.txt - fnmatch * does NOT span / in some implementations
+        # but Python's fnmatch does match / with *
+        assert passes({"path": {"allowlist": ["/tmp/*"]}}, {"path": "/tmp/file"})
+
+
+# ── String: blocklist (glob) ───────────────────────────────────────────────────
+
+
+class TestBlocklist:
+    def test_passes_when_no_pattern_matches(self) -> None:
+        assert passes({"path": {"blocklist": ["/etc/shadow", "/etc/passwd"]}}, {"path": "/tmp/file"})
+
+    def test_fails_exact_blocked_path(self) -> None:
+        result = evaluate({"path": {"blocklist": ["/etc/shadow"]}}, {"path": "/etc/shadow"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "blocklist"
+
+    def test_fails_glob_blocked_path(self) -> None:
+        assert fails({"path": {"blocklist": ["/etc/**"]}}, {"path": "/etc/nginx/nginx.conf"})
+
+    def test_blocklist_and_allowlist_combined(self) -> None:
+        # Must match allowlist AND not match blocklist → both checked (AND logic)
+        result = evaluate(
+            {"path": {"allowlist": ["/etc/**"], "blocklist": ["/etc/shadow"]}},
+            {"path": "/etc/shadow"},
+        )
+        assert not result.passed
+
+
+# ── String: max_length ─────────────────────────────────────────────────────────
+
+
+class TestMaxLength:
+    def test_passes_within_limit(self) -> None:
+        assert passes({"name": {"max_length": 50}}, {"name": "Alice"})
+
+    def test_fails_exceeds_limit(self) -> None:
+        result = evaluate({"name": {"max_length": 5}}, {"name": "AliceBobCharlie"})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "max_length"
+
+
+# ── Numeric constraints ────────────────────────────────────────────────────────
+
+
+class TestNumericConstraints:
+    def test_min_value_passes(self) -> None:
+        assert passes({"count": {"min_value": 1}}, {"count": 5})
+
+    def test_min_value_fails_below(self) -> None:
+        result = evaluate({"count": {"min_value": 1}}, {"count": 0})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "min_value"
+
+    def test_min_value_boundary_inclusive(self) -> None:
+        assert passes({"count": {"min_value": 1}}, {"count": 1})
+
+    def test_max_value_passes(self) -> None:
+        assert passes({"max_ports": {"max_value": 100}}, {"max_ports": 80})
+
+    def test_max_value_fails_above(self) -> None:
+        result = evaluate({"max_ports": {"max_value": 100}}, {"max_ports": 101})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "max_value"
+
+    def test_max_value_boundary_inclusive(self) -> None:
+        assert passes({"max_ports": {"max_value": 100}}, {"max_ports": 100})
+
+    def test_min_and_max_combined(self) -> None:
+        assert passes({"val": {"min_value": 1, "max_value": 10}}, {"val": 5})
+        assert fails({"val": {"min_value": 1, "max_value": 10}}, {"val": 11})
+
+    def test_float_values(self) -> None:
+        assert passes({"ratio": {"min_value": 0.0, "max_value": 1.0}}, {"ratio": 0.5})
+        assert fails({"ratio": {"min_value": 0.0, "max_value": 1.0}}, {"ratio": 1.5})
+
+    def test_booleans_not_treated_as_numeric(self) -> None:
+        # True/False are bool subclass of int in Python — must not be min/max checked
+        result = evaluate({"val": {"min_value": 0}}, {"val": True})
+        assert result.passed  # bool skips numeric check
+
+
+# ── Boolean constraints ────────────────────────────────────────────────────────
+
+
+class TestBooleanConstraints:
+    def test_must_be_true_passes(self) -> None:
+        assert passes({"confirmed": {"must_be": True}}, {"confirmed": True})
+
+    def test_must_be_true_fails_false(self) -> None:
+        result = evaluate({"confirmed": {"must_be": True}}, {"confirmed": False})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "must_be"
+
+    def test_must_be_false_passes(self) -> None:
+        assert passes({"dry_run": {"must_be": False}}, {"dry_run": False})
+
+    def test_must_be_fails_non_bool(self) -> None:
+        result = evaluate({"confirmed": {"must_be": True}}, {"confirmed": "true"})
+        assert not result.passed
+
+    def test_must_be_stops_further_checks(self) -> None:
+        # must_be check returns early — other constraints not evaluated
+        result = evaluate(
+            {"v": {"must_be": True, "one_of": [True]}},
+            {"v": False},
+        )
+        assert not result.passed
+        assert len(result.violations) == 1
+        assert result.violations[0].constraint_type == "must_be"
+
+
+# ── Array constraints ──────────────────────────────────────────────────────────
+
+
+class TestArrayConstraints:
+    def test_max_items_passes(self) -> None:
+        assert passes({"tags": {"max_items": 5}}, {"tags": ["a", "b", "c"]})
+
+    def test_max_items_fails_exceeds(self) -> None:
+        result = evaluate({"tags": {"max_items": 2}}, {"tags": ["a", "b", "c"]})
+        assert not result.passed
+        assert result.violations[0].constraint_type == "max_items"
+
+    def test_item_constraints_applied_to_each(self) -> None:
+        result = evaluate(
+            {"hosts": {"item_constraints": {"must_not_contain": ["internal"]}}},
+            {"hosts": ["api.github.com", "api.internal.corp"]},
+        )
+        assert not result.passed
+        # Violation should reference the second item
+        assert "[1]" in result.violations[0].argument
+
+    def test_item_constraints_all_pass(self) -> None:
+        assert passes(
+            {"hosts": {"item_constraints": {"must_not_contain": ["internal"]}}},
+            {"hosts": ["api.github.com", "api.example.com"]},
+        )
+
+    def test_item_constraints_one_of(self) -> None:
+        assert passes(
+            {"methods": {"item_constraints": {"one_of": ["GET", "POST"]}}},
+            {"methods": ["GET", "POST"]},
+        )
+        assert fails(
+            {"methods": {"item_constraints": {"one_of": ["GET", "POST"]}}},
+            {"methods": ["GET", "DELETE"]},
+        )
+
+    def test_max_items_and_item_constraints_combined(self) -> None:
+        result = evaluate(
+            {"tags": {"max_items": 2, "item_constraints": {"max_length": 5}}},
+            {"tags": ["short", "also-short", "way-too-long"]},
+        )
+        assert not result.passed
+        # Both max_items AND item constraint violation
+        types = {v.constraint_type for v in result.violations}
+        assert "max_items" in types
+
+
+# ── Nested argument access (dot notation) ──────────────────────────────────────
+
+
+class TestNestedAccess:
+    def test_simple_dot_path(self) -> None:
+        assert passes(
+            {"options.timeout": {"max_value": 30}},
+            {"options": {"timeout": 10}},
+        )
+
+    def test_dot_path_fails(self) -> None:
+        result = evaluate(
+            {"options.timeout": {"max_value": 30}},
+            {"options": {"timeout": 60}},
+        )
+        assert not result.passed
+
+    def test_deep_dot_path(self) -> None:
+        assert passes(
+            {"config.network.proxy.port": {"max_value": 65535}},
+            {"config": {"network": {"proxy": {"port": 8080}}}},
+        )
+
+    def test_missing_intermediate_key(self) -> None:
+        # options.timeout missing because options dict has no 'timeout'
+        result = evaluate(
+            {"options.timeout": {"max_value": 30}},
+            {"options": {"retries": 3}},
+        )
+        assert not result.passed
+        assert result.violations[0].constraint_type == "required"
+
+
+# ── Network: domain matching ───────────────────────────────────────────────────
+
+
+class TestDomainMatching:
+    def test_exact_match(self) -> None:
+        assert _domain_matches("api.github.com", "api.github.com")
+        assert not _domain_matches("other.github.com", "api.github.com")
+
+    def test_wildcard_subdomain(self) -> None:
+        assert _domain_matches("api.github.com", "*.github.com")
+        assert _domain_matches("uploads.github.com", "*.github.com")
+
+    def test_wildcard_does_not_match_root(self) -> None:
+        assert not _domain_matches("github.com", "*.github.com")
+
+    def test_wildcard_matches_deep_subdomain(self) -> None:
+        # *.github.com DOES match deep.api.github.com — for blocked_domains this
+        # is the correct security behaviour: block all subdomains, not just one level.
+        assert _domain_matches("deep.api.github.com", "*.github.com")
+
+    def test_case_insensitive(self) -> None:
+        assert _domain_matches("API.GITHUB.COM", "api.github.com")
+        assert _domain_matches("api.github.com", "*.GITHUB.COM")
+
+
+class TestAllowedDomains:
+    def test_passes_allowed_domain(self) -> None:
+        assert passes(
+            {"url": {"allowed_domains": ["api.github.com", "api.slack.com"]}},
+            {"url": "https://api.github.com/repos"},
+        )
+
+    def test_fails_blocked_domain(self) -> None:
+        result = evaluate(
+            {"url": {"allowed_domains": ["api.github.com"]}},
+            {"url": "https://evil.com/steal"},
+        )
+        assert not result.passed
+        assert result.violations[0].constraint_type == "allowed_domains"
+
+    def test_wildcard_domain_allowed(self) -> None:
+        assert passes(
+            {"url": {"allowed_domains": ["*.github.com"]}},
+            {"url": "https://api.github.com/v3"},
+        )
+
+    def test_bare_hostname_without_scheme(self) -> None:
+        assert passes(
+            {"target": {"allowed_domains": ["api.github.com"]}},
+            {"target": "api.github.com"},
+        )
+
+
+class TestBlockedDomains:
+    def test_passes_non_blocked_domain(self) -> None:
+        assert passes(
+            {"url": {"blocked_domains": ["*.internal.corp"]}},
+            {"url": "https://api.github.com"},
+        )
+
+    def test_fails_blocked_wildcard(self) -> None:
+        result = evaluate(
+            {"url": {"blocked_domains": ["*.internal.corp"]}},
+            {"url": "https://secrets.internal.corp/api"},
+        )
+        assert not result.passed
+        assert result.violations[0].constraint_type == "blocked_domains"
+
+    def test_fails_exact_blocked(self) -> None:
+        assert fails(
+            {"url": {"blocked_domains": ["evil.com"]}},
+            {"url": "https://evil.com"},
+        )
+
+
+class TestAllowedSchemes:
+    def test_passes_https(self) -> None:
+        assert passes(
+            {"url": {"allowed_schemes": ["https"]}},
+            {"url": "https://api.example.com"},
+        )
+
+    def test_fails_http(self) -> None:
+        result = evaluate(
+            {"url": {"allowed_schemes": ["https"]}},
+            {"url": "http://api.example.com"},
+        )
+        assert not result.passed
+        assert result.violations[0].constraint_type == "allowed_schemes"
+
+    def test_fails_ftp(self) -> None:
+        assert fails(
+            {"url": {"allowed_schemes": ["https", "http"]}},
+            {"url": "ftp://files.example.com"},
+        )
+
+
+# ── Network: CIDR matching ─────────────────────────────────────────────────────
+
+
+class TestCIDRMatching:
+    def test_ip_in_cidr(self) -> None:
+        import ipaddress
+        ip = ipaddress.ip_address("10.0.1.5")
+        assert _ip_in_cidr(ip, "10.0.0.0/8")
+        assert not _ip_in_cidr(ip, "192.168.0.0/16")
+
+    def test_ip_in_slash_32(self) -> None:
+        import ipaddress
+        ip = ipaddress.ip_address("192.168.1.1")
+        assert _ip_in_cidr(ip, "192.168.1.1/32")
+        assert not _ip_in_cidr(ip, "192.168.1.2/32")
+
+    def test_ip_in_slash_0(self) -> None:
+        import ipaddress
+        # /0 matches everything
+        assert _ip_in_cidr(ipaddress.ip_address("1.2.3.4"), "0.0.0.0/0")
+
+    def test_ipv6_cidr(self) -> None:
+        import ipaddress
+        ip = ipaddress.ip_address("2001:db8::1")
+        assert _ip_in_cidr(ip, "2001:db8::/32")
+        assert not _ip_in_cidr(ip, "2001:db9::/32")
+
+    def test_malformed_cidr_returns_false(self) -> None:
+        import ipaddress
+        ip = ipaddress.ip_address("10.0.0.1")
+        assert not _ip_in_cidr(ip, "not-a-cidr")
+
+
+class TestAllowedCIDRs:
+    def test_passes_ip_in_allowed_range(self) -> None:
+        assert passes(
+            {"target": {"allowed_cidrs": ["10.0.0.0/8"]}},
+            {"target": "10.1.2.3"},
+        )
+
+    def test_fails_ip_outside_allowed_range(self) -> None:
+        result = evaluate(
+            {"target": {"allowed_cidrs": ["10.0.0.0/8"]}},
+            {"target": "192.168.1.1"},
+        )
+        assert not result.passed
+        assert result.violations[0].constraint_type == "allowed_cidrs"
+
+    def test_dns_name_skips_cidr_check(self) -> None:
+        # DNS names can't be CIDR-checked without resolution — should pass silently
+        result = evaluate(
+            {"target": {"allowed_cidrs": ["10.0.0.0/8"]}},
+            {"target": "api.example.com"},
+        )
+        assert result.passed
+
+
+class TestBlockedCIDRs:
+    def test_passes_ip_not_in_blocked(self) -> None:
+        assert passes(
+            {"target": {"blocked_cidrs": ["0.0.0.0/0"]}},
+            {"target": "api.github.com"},  # DNS name, not an IP
+        )
+
+    def test_fails_ip_in_blocked_range(self) -> None:
+        result = evaluate(
+            {"target": {"blocked_cidrs": ["192.168.0.0/16"]}},
+            {"target": "192.168.1.100"},
+        )
+        assert not result.passed
+        assert result.violations[0].constraint_type == "blocked_cidrs"
+
+    def test_slash_zero_blocks_everything(self) -> None:
+        assert fails(
+            {"target": {"blocked_cidrs": ["0.0.0.0/0"]}},
+            {"target": "1.2.3.4"},
+        )
+
+    def test_ip_from_url_in_blocked_cidr(self) -> None:
+        assert fails(
+            {"url": {"blocked_cidrs": ["10.0.0.0/8"]}},
+            {"url": "https://10.0.0.1/api"},
+        )
+
+
+# ── Network: ports ─────────────────────────────────────────────────────────────
+
+
+class TestPortConstraints:
+    def test_port_in_list(self) -> None:
+        assert _port_in_list(443, [80, 443])
+        assert not _port_in_list(8080, [80, 443])
+
+    def test_port_in_range(self) -> None:
+        assert _port_in_list(8500, ["8000-9000"])
+        assert not _port_in_list(7999, ["8000-9000"])
+
+    def test_port_boundary_inclusive(self) -> None:
+        assert _port_in_list(8000, ["8000-9000"])
+        assert _port_in_list(9000, ["8000-9000"])
+
+    def test_port_mixed_list(self) -> None:
+        assert _port_in_list(443, [80, 443, "8000-9000"])
+        assert _port_in_list(8080, [80, 443, "8000-9000"])
+
+    def test_allowed_ports_in_url(self) -> None:
+        assert passes(
+            {"url": {"allowed_ports": [443, "8000-9000"]}},
+            {"url": "https://api.example.com:8080/v1"},
+        )
+        assert fails(
+            {"url": {"allowed_ports": [443]}},
+            {"url": "https://api.example.com:9090/v1"},
+        )
+
+
+# ── URL parsing edge cases ─────────────────────────────────────────────────────
+
+
+class TestURLParsing:
+    def test_url_with_scheme(self) -> None:
+        p = _parse_url_lenient("https://api.example.com/path")
+        assert p.hostname == "api.example.com"
+        assert p.scheme == "https"
+
+    def test_url_without_scheme(self) -> None:
+        p = _parse_url_lenient("api.example.com/path")
+        assert p.hostname == "api.example.com"
+
+    def test_ip_address_url(self) -> None:
+        p = _parse_url_lenient("https://10.0.0.1:8080/api")
+        assert p.hostname == "10.0.0.1"
+        assert p.port == 8080
+
+    def test_bare_ip(self) -> None:
+        p = _parse_url_lenient("192.168.1.1")
+        assert p.hostname == "192.168.1.1"
+
+    def test_url_with_port(self) -> None:
+        p = _parse_url_lenient("https://api.example.com:8443/")
+        assert p.port == 8443
+
+    def test_url_with_path_and_query(self) -> None:
+        p = _parse_url_lenient("https://api.example.com/v1/repos?page=1")
+        assert p.hostname == "api.example.com"
+        assert p.scheme == "https"
+
+
+# ── AND logic: multiple constraints on same argument ──────────────────────────
+
+
+class TestAndLogic:
+    def test_multiple_string_constraints_all_pass(self) -> None:
+        assert passes(
+            {"path": {
+                "must_start_with": ["/workspace/"],
+                "must_not_contain": [".."],
+                "allowlist": ["/workspace/**"],
+            }},
+            {"path": "/workspace/src/main.py"},
+        )
+
+    def test_multiple_string_constraints_one_fails(self) -> None:
+        result = evaluate(
+            {"path": {
+                "must_start_with": ["/workspace/"],
+                "must_not_contain": [".."],
+            }},
+            {"path": "/workspace/../etc/passwd"},
+        )
+        assert not result.passed
+        assert result.violations[0].constraint_type == "must_not_contain"
+
+    def test_two_args_both_must_pass(self) -> None:
+        result = evaluate(
+            {
+                "url": {"allowed_schemes": ["https"]},
+                "method": {"one_of": ["GET", "POST"]},
+            },
+            {"url": "http://api.example.com", "method": "DELETE"},
+        )
+        assert not result.passed
+        types = {v.constraint_type for v in result.violations}
+        assert "allowed_schemes" in types
+        assert "one_of" in types
+
+    def test_first_arg_fails_second_arg_still_checked(self) -> None:
+        # Both args are independently evaluated
+        result = evaluate(
+            {
+                "a": {"must_start_with": ["/safe"]},
+                "b": {"max_value": 10},
+            },
+            {"a": "/unsafe", "b": 100},
+        )
+        assert not result.passed
+        assert len(result.violations) == 2
+
+
+# ── Engine integration ─────────────────────────────────────────────────────────
+
+
+def _make_policy_with_caps(capabilities_yaml: str) -> AgentWardPolicy:
+    """Build a minimal policy with capabilities from YAML snippet."""
+    full_yaml = textwrap.dedent(f"""\
+        version: "1.0"
+        skills:
+          test-skill:
+            file:
+              read: true
+              write: true
+              capabilities:
+                {textwrap.indent(capabilities_yaml.strip(), "                ")}
+    """)
+    return AgentWardPolicy(**yaml.safe_load(full_yaml))
+
+
+class TestEngineIntegration:
+    def test_no_capabilities_works_as_before(self) -> None:
+        """Backward compat: policy without capabilities evaluates normally."""
+        import pathlib
+        policy = AgentWardPolicy(
+            version="1.0",
+            skills={"test-skill": {"file": ResourcePermissions(actions={"read": True})}},
+        )
+        engine = PolicyEngine(policy)
+        # Protected paths (SSH keys, AWS creds) are still blocked by the safety floor.
+        # Use the actual home directory to ensure the path matches.
+        ssh_key = str(pathlib.Path.home() / ".ssh" / "id_rsa")
+        result = engine.evaluate("file_read", {"path": ssh_key})
+        assert result.decision == PolicyDecision.BLOCK  # protected path invariant
+
+    def test_no_capabilities_read_allowed(self) -> None:
+        policy = AgentWardPolicy(
+            version="1.0",
+            skills={"test-skill": {"file": ResourcePermissions(actions={"read": True})}},
+        )
+        engine = PolicyEngine(policy)
+        result = engine.evaluate("file_read", {"path": "/tmp/notes.txt"})
+        assert result.decision == PolicyDecision.ALLOW
+
+    def test_capabilities_block_forbidden_path(self) -> None:
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              fs:
+                file:
+                  read: true
+                  write: true
+                  capabilities:
+                    write_file:
+                      path:
+                        must_start_with: ["/tmp/", "/workspace/"]
+                        must_not_contain: [".."]
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+        engine = PolicyEngine(policy)
+
+        # Allowed path
+        r = engine.evaluate("write_file", {"path": "/tmp/output.txt"})
+        assert r.decision == PolicyDecision.ALLOW
+
+        # Forbidden path — not in must_start_with
+        r = engine.evaluate("write_file", {"path": "/etc/cron.d/backdoor"})
+        assert r.decision == PolicyDecision.BLOCK
+        assert "must_start_with" in r.reason
+
+        # Path traversal attempt
+        r = engine.evaluate("write_file", {"path": "/workspace/../etc/passwd"})
+        assert r.decision == PolicyDecision.BLOCK
+        assert "must_not_contain" in r.reason
+
+    def test_capabilities_block_wrong_http_method(self) -> None:
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              net:
+                http:
+                  read: true
+                  capabilities:
+                    http_request:
+                      url:
+                        allowed_domains: ["api.github.com"]
+                        allowed_schemes: ["https"]
+                      method:
+                        one_of: ["GET", "POST"]
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+        engine = PolicyEngine(policy)
+
+        r = engine.evaluate("http_request", {"url": "https://api.github.com/v3", "method": "GET"})
+        assert r.decision == PolicyDecision.ALLOW
+
+        r = engine.evaluate("http_request", {"url": "https://api.github.com/v3", "method": "DELETE"})
+        assert r.decision == PolicyDecision.BLOCK
+        assert "one_of" in r.reason
+
+        r = engine.evaluate("http_request", {"url": "http://evil.com", "method": "GET"})
+        assert r.decision == PolicyDecision.BLOCK
+
+    def test_capabilities_block_nmap_outside_allowed_cidr(self) -> None:
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              scanning:
+                nmap:
+                  read: true
+                  capabilities:
+                    nmap_scan:
+                      target:
+                        allowed_cidrs: ["10.0.0.0/8", "192.168.0.0/16"]
+                      scan_type:
+                        one_of: ["connect", "version"]
+                      max_ports:
+                        max_value: 100
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+        engine = PolicyEngine(policy)
+
+        # Allowed target in 10.0.0.0/8
+        r = engine.evaluate("nmap_scan", {"target": "10.1.2.3", "scan_type": "connect", "max_ports": 50})
+        assert r.decision == PolicyDecision.ALLOW
+
+        # Blocked: target outside allowed CIDRs
+        r = engine.evaluate("nmap_scan", {"target": "8.8.8.8", "scan_type": "connect", "max_ports": 50})
+        assert r.decision == PolicyDecision.BLOCK
+        assert "allowed_cidrs" in r.reason
+
+        # Blocked: scan_type not in one_of
+        r = engine.evaluate("nmap_scan", {"target": "10.1.2.3", "scan_type": "stealth", "max_ports": 50})
+        assert r.decision == PolicyDecision.BLOCK
+
+        # Blocked: max_ports exceeds limit
+        r = engine.evaluate("nmap_scan", {"target": "10.1.2.3", "scan_type": "connect", "max_ports": 200})
+        assert r.decision == PolicyDecision.BLOCK
+        assert "max_value" in r.reason
+
+    def test_capabilities_missing_required_arg_blocked(self) -> None:
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              fs:
+                file:
+                  write: true
+                  capabilities:
+                    write_file:
+                      path:
+                        must_start_with: ["/tmp/"]
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+        engine = PolicyEngine(policy)
+
+        r = engine.evaluate("write_file", {})  # no path argument
+        assert r.decision == PolicyDecision.BLOCK
+        assert "required" in r.reason.lower() or "path" in r.reason
+
+    def test_tool_without_capabilities_not_blocked(self) -> None:
+        """Only the specific tool with capabilities is constrained."""
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              fs:
+                file:
+                  read: true
+                  write: true
+                  capabilities:
+                    write_file:
+                      path:
+                        must_start_with: ["/tmp/"]
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+        engine = PolicyEngine(policy)
+
+        # read_file has no capability constraints — should pass unconstrained
+        r = engine.evaluate("read_file", {"path": "/etc/hosts"})
+        # Protected paths block /etc/* — but that's the protected path check, not capabilities
+        # Use a safe path to test capabilities aren't applied to unconstrained tools
+        r = engine.evaluate("read_file", {"path": "/tmp/notes.txt"})
+        assert r.decision == PolicyDecision.ALLOW
+
+    def test_skill_and_resource_preserved_in_block(self) -> None:
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              my-skill:
+                myres:
+                  read: true
+                  capabilities:
+                    myres_read:
+                      path:
+                        must_start_with: ["/safe"]
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+        engine = PolicyEngine(policy)
+
+        r = engine.evaluate("myres_read", {"path": "/unsafe"})
+        assert r.decision == PolicyDecision.BLOCK
+        assert r.skill == "my-skill"
+        assert r.resource == "myres"
+
+    def test_block_reason_is_specific_not_vague(self) -> None:
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              fs:
+                file:
+                  write: true
+                  capabilities:
+                    write_file:
+                      path:
+                        blocklist: ["/etc/shadow", "/etc/passwd"]
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+        engine = PolicyEngine(policy)
+
+        r = engine.evaluate("write_file", {"path": "/etc/shadow"})
+        assert r.decision == PolicyDecision.BLOCK
+        assert "BLOCKED" in r.reason
+        assert "path" in r.reason
+        assert "/etc/shadow" in r.reason
+        assert "blocklist" in r.reason
+
+
+# ── Backward compatibility ─────────────────────────────────────────────────────
+
+
+class TestBackwardCompatibility:
+    def test_existing_policy_no_capabilities_field(self) -> None:
+        """Policies without capabilities load and evaluate without changes."""
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              email-manager:
+                gmail:
+                  read: true
+                  send: false
+                  filters:
+                    exclude_labels: ["Finance", "Medical"]
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+        engine = PolicyEngine(policy)
+
+        r = engine.evaluate("gmail_read", {"label": "inbox"})
+        assert r.decision == PolicyDecision.ALLOW
+
+        r = engine.evaluate("gmail_send", {"to": "user@example.com"})
+        assert r.decision == PolicyDecision.BLOCK
+
+    def test_filters_still_work_alongside_capabilities(self) -> None:
+        """Filters and capabilities coexist — filters run first."""
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              fs:
+                file:
+                  read: true
+                  filters:
+                    only_from: ["trusted_source"]
+                  capabilities:
+                    read_file:
+                      path:
+                        must_start_with: ["/tmp/"]
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+        engine = PolicyEngine(policy)
+
+        # Fails only_from filter (no "trusted_source" in args) — before caps
+        r = engine.evaluate("read_file", {"path": "/tmp/file"})
+        assert r.decision == PolicyDecision.BLOCK
+        assert "only_from" in r.reason
+
+
+# ── YAML round-trip ────────────────────────────────────────────────────────────
+
+
+class TestYAMLRoundTrip:
+    def test_capabilities_load_from_yaml_string(self) -> None:
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              filesystem-manager:
+                file:
+                  read: true
+                  write: true
+                  capabilities:
+                    write_file:
+                      path:
+                        must_start_with: ["/tmp/", "/workspace/"]
+                        must_not_start_with: ["/etc/", "/home/"]
+                        must_not_contain: [".."]
+                    read_file:
+                      path:
+                        allowlist: ["/workspace/**", "/public/**"]
+                        blocklist: ["/etc/shadow", "/etc/passwd"]
+              network-tools:
+                http:
+                  read: true
+                  capabilities:
+                    http_request:
+                      url:
+                        allowed_domains: ["api.github.com", "api.slack.com"]
+                        blocked_domains: ["*.internal.corp"]
+                        allowed_schemes: ["https"]
+                      method:
+                        one_of: ["GET", "POST"]
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+
+        # Verify parsing
+        fs_caps = policy.skills["filesystem-manager"]["file"].capabilities
+        assert "write_file" in fs_caps
+        assert "read_file" in fs_caps
+
+        write_path = fs_caps["write_file"]["path"]
+        assert write_path.must_start_with == ["/tmp/", "/workspace/"]
+        assert write_path.must_not_contain == [".."]
+
+        read_path = fs_caps["read_file"]["path"]
+        assert "/workspace/**" in read_path.allowlist
+        assert "/etc/shadow" in read_path.blocklist
+
+        net_caps = policy.skills["network-tools"]["http"].capabilities
+        url_c = net_caps["http_request"]["url"]
+        assert "api.github.com" in url_c.allowed_domains
+        assert "*.internal.corp" in url_c.blocked_domains
+        assert url_c.allowed_schemes == ["https"]
+
+        method_c = net_caps["http_request"]["method"]
+        assert "GET" in method_c.one_of
+
+    def test_full_policy_yaml_example(self) -> None:
+        """Test the full YAML example from the spec."""
+        policy_yaml = textwrap.dedent("""\
+            version: "1.0"
+            skills:
+              scanning-tools:
+                nmap:
+                  read: true
+                  capabilities:
+                    nmap_scan:
+                      target:
+                        allowed_cidrs: ["10.0.0.0/8", "192.168.0.0/16"]
+                        blocked_cidrs: ["0.0.0.0/0"]
+                      scan_type:
+                        one_of: ["connect", "version"]
+                      max_ports:
+                        max_value: 100
+        """)
+        policy = AgentWardPolicy(**yaml.safe_load(policy_yaml))
+        caps = policy.skills["scanning-tools"]["nmap"].capabilities["nmap_scan"]
+
+        target = caps["target"]
+        assert "10.0.0.0/8" in target.allowed_cidrs
+        assert "0.0.0.0/0" in target.blocked_cidrs
+
+        scan_type = caps["scan_type"]
+        assert scan_type.one_of == ["connect", "version"]
+
+        max_ports = caps["max_ports"]
+        assert max_ports.max_value == 100
+
+
+# ── Schema: ArgumentConstraints model validation ───────────────────────────────
+
+
+class TestArgumentConstraintsSchema:
+    def test_empty_constraints_valid(self) -> None:
+        c = ArgumentConstraints()
+        assert c.must_start_with == []
+        assert c.fail_open is False
+
+    def test_fail_open_default_false(self) -> None:
+        c = ArgumentConstraints(must_start_with=["/tmp"])
+        assert c.fail_open is False
+
+    def test_regex_compiled_at_construction(self) -> None:
+        c = ArgumentConstraints(matches=[r"^\d+$"])
+        assert len(c._compiled_matches) == 1
+
+    def test_not_matches_compiled(self) -> None:
+        c = ArgumentConstraints(not_matches=[r"\brm\b"])
+        assert len(c._compiled_not_matches) == 1
+
+    def test_resource_permissions_with_capabilities(self) -> None:
+        rp = ResourcePermissions(**{
+            "read": True,
+            "capabilities": {
+                "read_file": {
+                    "path": {"must_start_with": ["/tmp/"]}
+                }
+            }
+        })
+        assert rp.actions["read"] is True
+        assert "read_file" in rp.capabilities
+        assert rp.capabilities["read_file"]["path"].must_start_with == ["/tmp/"]
+
+    def test_resource_permissions_denied_clears_capabilities(self) -> None:
+        rp = ResourcePermissions(denied=True)
+        assert rp.denied is True
+        assert rp.capabilities == {}
+
+    def test_item_constraints_recursive(self) -> None:
+        c = ArgumentConstraints(
+            max_items=5,
+            item_constraints=ArgumentConstraints(must_not_contain=["evil"]),
+        )
+        assert c.item_constraints is not None
+        assert c.item_constraints.must_not_contain == ["evil"]


### PR DESCRIPTION
## Summary

- New `capabilities` block in policy YAML for per-tool argument constraints, wired into `engine.py` as the final gate before ALLOW — fully backward compatible (no `capabilities` block = works as before)
- New `agentward/policy/constraints.py` (705 lines) — standalone constraint evaluator with no external dependencies
- Supports string constraints: `must_start_with`, `must_not_contain`, allowlist/blocklist globs, regex, `one_of`
- Supports network constraints: `allowed_domains` with wildcards, CIDR allowlist/blocklist, scheme enforcement, port ranges
- Supports numeric constraints (`min`/`max` value) and boolean constraints
- Nested argument access via dot notation (e.g. `params.url`, `options.path`)
- Fail-closed by default for missing required arguments
- 131 new tests (`tests/test_constraints.py`), 2273 total passing
- 20 new regression probes: `capability_path_traversal.yaml` (9 cases) + `capability_network_scope.yaml` (11 cases)
- README updated with capability scoping section and YAML examples

## Test plan

- [ ] `pytest tests/test_constraints.py` — all 131 constraint tests pass
- [ ] `agentward probe` — 2273 total passing including 20 new regression probes
- [ ] Add a `capabilities:` block to an existing policy YAML and verify argument-level blocking works end-to-end via `agentward inspect`
- [ ] Verify policy without `capabilities:` block continues to behave identically (backward compatibility)